### PR TITLE
fix(tests): fix orleans reference

### DIFF
--- a/test/SignalR.Orleans.Tests/SignalR.Orleans.Tests.csproj
+++ b/test/SignalR.Orleans.Tests/SignalR.Orleans.Tests.csproj
@@ -13,10 +13,10 @@
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Core" Version="1.0.0-alpha2-final" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.0.0-alpha2-final" />
     <PackageReference Include="Microsoft.AspNetCore.Sockets" Version="1.0.0-alpha2-final" />
-    <PackageReference Include="Microsoft.Orleans.Core" Version="2.0.0-*" />
-    <PackageReference Include="Microsoft.Orleans.OrleansProviders" Version="2.0.0-*" />
-    <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="2.0.0-*" />
-    <PackageReference Include="Microsoft.Orleans.OrleansCodeGenerator.Build" Version="2.0.0-*" />
+    <PackageReference Include="Microsoft.Orleans.Core" Version="2.0.0-beta*" />
+    <PackageReference Include="Microsoft.Orleans.OrleansProviders" Version="2.0.0-beta*" />
+    <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="2.0.0-beta*" />
+    <PackageReference Include="Microsoft.Orleans.OrleansCodeGenerator.Build" Version="2.0.0-beta*" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
set beta prefix since the old version `preview` is greater than `beta`.