### PR TITLE
Update to signalr-1.0.0-preview1-final

### DIFF
--- a/src/SignalR.Orleans/Core/GrainExtensions.cs
+++ b/src/SignalR.Orleans/Core/GrainExtensions.cs
@@ -13,7 +13,7 @@ namespace Orleans
     {
         public static async Task SendSignalRMessage(this IConnectionGrain grain, string methodName, params object[] message)
         {
-            var invocationMessage = new InvocationMessage(Guid.NewGuid().ToString(), nonBlocking: true, target: methodName, arguments: message);
+            var invocationMessage = new InvocationMessage(target: methodName, argumentBindingException: null, arguments: message);
             await grain.SendMessage(invocationMessage);
         }
     }

--- a/src/SignalR.Orleans/Groups/GroupGrain.cs
+++ b/src/SignalR.Orleans/Groups/GroupGrain.cs
@@ -1,3 +1,7 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Orleans;
 using Orleans.Providers;
 using SignalR.Orleans.Core;
 
@@ -6,6 +10,19 @@ namespace SignalR.Orleans.Groups
     [StorageProvider(ProviderName = Constants.STORAGE_PROVIDER)]
     internal class GroupGrain : ConnectionGrain<GroupState>, IGroupGrain
     {
+        public Task SendMessageExcept(object message, IReadOnlyList<string> excludedIds)
+        {
+            var tasks = new List<Task>();
+            foreach (var connection in this.State.Connections)
+            {
+                if (excludedIds.Contains(connection.Key)) continue;
+
+                var client = GrainFactory.GetClientGrain(State.HubName, connection.Key);
+                tasks.Add(client.SendMessage(message));
+            }
+
+            return Task.WhenAll(tasks);
+        }
     }
 
     internal class GroupState : ConnectionState

--- a/src/SignalR.Orleans/Groups/IGroupGrain.cs
+++ b/src/SignalR.Orleans/Groups/IGroupGrain.cs
@@ -1,8 +1,11 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
 using SignalR.Orleans.Core;
 
 namespace SignalR.Orleans.Groups
 {
     public interface IGroupGrain : IConnectionGrain
     {
+        Task SendMessageExcept(object message, IReadOnlyList<string> excludedIds);
     }
 }

--- a/src/SignalR.Orleans/OrleansHubLifetimeManager.cs
+++ b/src/SignalR.Orleans/OrleansHubLifetimeManager.cs
@@ -106,7 +106,7 @@ namespace SignalR.Orleans
             return SendExternal(connectionId, message);
         }
 
-        public override Task SendConnectionsAsync(IReadOnlyList<string> connectionIds, string methodName, object[ ] args)
+        public override Task SendConnectionsAsync(IReadOnlyList<string> connectionIds, string methodName, object[] args)
         {
             var tasks = connectionIds.Select(c => SendConnectionAsync(c, methodName, args));
             return Task.WhenAll(tasks);
@@ -121,7 +121,7 @@ namespace SignalR.Orleans
             return group.SendSignalRMessage(methodName, args);
         }
 
-        public override Task SendGroupExceptAsync(string groupName, string methodName, object[ ] args, IReadOnlyList<string> excludedIds)
+        public override Task SendGroupExceptAsync(string groupName, string methodName, object[] args, IReadOnlyList<string> excludedIds)
         {
             if (string.IsNullOrWhiteSpace(groupName)) throw new ArgumentNullException(nameof(groupName));
             if (string.IsNullOrWhiteSpace(methodName)) throw new ArgumentNullException(nameof(methodName));
@@ -131,7 +131,7 @@ namespace SignalR.Orleans
             return group.SendMessageExcept(invocationMessage, excludedIds);
         }
 
-        public override Task SendGroupsAsync(IReadOnlyList<string> groupNames, string methodName, object[ ] args)
+        public override Task SendGroupsAsync(IReadOnlyList<string> groupNames, string methodName, object[] args)
         {
             var tasks = groupNames.Select(g => SendGroupAsync(g, methodName, args));
             return Task.WhenAll(tasks);
@@ -146,7 +146,7 @@ namespace SignalR.Orleans
             return user.SendSignalRMessage(methodName, args);
         }
 
-        public override Task SendUsersAsync(IReadOnlyList<string> userIds, string methodName, object[ ] args)
+        public override Task SendUsersAsync(IReadOnlyList<string> userIds, string methodName, object[] args)
         {
             var tasks = userIds.Select(u => SendGroupAsync(u, methodName, args));
             return Task.WhenAll(tasks);

--- a/src/SignalR.Orleans/OrleansHubLifetimeManager.cs
+++ b/src/SignalR.Orleans/OrleansHubLifetimeManager.cs
@@ -121,6 +121,16 @@ namespace SignalR.Orleans
             return group.SendSignalRMessage(methodName, args);
         }
 
+        public override Task SendGroupExceptAsync(string groupName, string methodName, object[ ] args, IReadOnlyList<string> excludedIds)
+        {
+            if (string.IsNullOrWhiteSpace(groupName)) throw new ArgumentNullException(nameof(groupName));
+            if (string.IsNullOrWhiteSpace(methodName)) throw new ArgumentNullException(nameof(methodName));
+
+            var group = this._clusterClient.GetGroupGrain(_hubName, groupName);
+            var invocationMessage = new InvocationMessage(target: methodName, argumentBindingException: null, arguments: args);
+            return group.SendMessageExcept(invocationMessage, excludedIds);
+        }
+
         public override Task SendGroupsAsync(IReadOnlyList<string> groupNames, string methodName, object[ ] args)
         {
             var tasks = groupNames.Select(g => SendGroupAsync(g, methodName, args));

--- a/src/SignalR.Orleans/OrleansHubLifetimeManager.cs
+++ b/src/SignalR.Orleans/OrleansHubLifetimeManager.cs
@@ -106,6 +106,12 @@ namespace SignalR.Orleans
             return SendExternal(connectionId, message);
         }
 
+        public override Task SendConnectionsAsync(IReadOnlyList<string> connectionIds, string methodName, object[ ] args)
+        {
+            var tasks = connectionIds.Select(c => SendConnectionAsync(c, methodName, args));
+            return Task.WhenAll(tasks);
+        }
+
         public override Task SendGroupAsync(string groupName, string methodName, object[] args)
         {
             if (string.IsNullOrWhiteSpace(groupName)) throw new ArgumentNullException(nameof(groupName));
@@ -115,6 +121,12 @@ namespace SignalR.Orleans
             return group.SendSignalRMessage(methodName, args);
         }
 
+        public override Task SendGroupsAsync(IReadOnlyList<string> groupNames, string methodName, object[ ] args)
+        {
+            var tasks = groupNames.Select(g => SendGroupAsync(g, methodName, args));
+            return Task.WhenAll(tasks);
+        }
+
         public override Task SendUserAsync(string userId, string methodName, object[] args)
         {
             if (string.IsNullOrWhiteSpace(userId)) throw new ArgumentNullException(nameof(userId));
@@ -122,6 +134,12 @@ namespace SignalR.Orleans
 
             var user = this._clusterClient.GetUserGrain(_hubName, userId);
             return user.SendSignalRMessage(methodName, args);
+        }
+
+        public override Task SendUsersAsync(IReadOnlyList<string> userIds, string methodName, object[ ] args)
+        {
+            var tasks = userIds.Select(u => SendGroupAsync(u, methodName, args));
+            return Task.WhenAll(tasks);
         }
 
         public override async Task OnConnectedAsync(HubConnectionContext connection)

--- a/src/SignalR.Orleans/OrleansHubLifetimeManager.cs
+++ b/src/SignalR.Orleans/OrleansHubLifetimeManager.cs
@@ -62,7 +62,7 @@ namespace SignalR.Orleans
                     continue;
 
                 if (message.ExcludedIds == null || !message.ExcludedIds.Contains(connection.ConnectionId))
-                    allTasks.Add(this.InvokeLocal(connection, payload));
+                    allTasks.Add(this.SendLocal(connection, payload));
             }
             return Task.WhenAll(allTasks);
         }
@@ -72,7 +72,7 @@ namespace SignalR.Orleans
             var connection = this._connections[message.ConnectionId];
             if (connection == null) return Task.CompletedTask; // TODO: Log
 
-            return this.InvokeLocal(connection, (InvocationMessage)message.Payload);
+            return this.SendLocal(connection, (InvocationMessage)message.Payload);
         }
 
         public override Task AddGroupAsync(string connectionId, string groupName)
@@ -81,19 +81,19 @@ namespace SignalR.Orleans
             return group.Add(_hubName, connectionId);
         }
 
-        public override Task InvokeAllAsync(string methodName, object[] args)
+        public override Task SendAllAsync(string methodName, object[] args)
         {
             var message = new InvocationMessage(target: methodName, argumentBindingException: null, arguments: args);
             return this._allStream.OnNextAsync(new AllMessage { Payload = message });
         }
 
-        public override Task InvokeAllExceptAsync(string methodName, object[] args, IReadOnlyList<string> excludedIds)
+        public override Task SendAllExceptAsync(string methodName, object[] args, IReadOnlyList<string> excludedIds)
         {
             var message = new InvocationMessage(target: methodName, argumentBindingException: null, arguments: args);
             return this._allStream.OnNextAsync(new AllMessage { Payload = message, ExcludedIds = excludedIds });
         }
 
-        public override Task InvokeConnectionAsync(string connectionId, string methodName, object[] args)
+        public override Task SendConnectionAsync(string connectionId, string methodName, object[] args)
         {
             if (string.IsNullOrWhiteSpace(connectionId)) throw new ArgumentNullException(nameof(connectionId));
             if (string.IsNullOrWhiteSpace(methodName)) throw new ArgumentNullException(nameof(methodName));
@@ -101,12 +101,12 @@ namespace SignalR.Orleans
             var message = new InvocationMessage(target: methodName, argumentBindingException: null, arguments: args);
 
             var connection = this._connections[connectionId];
-            if (connection != null) return InvokeLocal(connection, message);
+            if (connection != null) return SendLocal(connection, message);
 
-            return InvokeExternal(connectionId, message);
+            return SendExternal(connectionId, message);
         }
 
-        public override Task InvokeGroupAsync(string groupName, string methodName, object[] args)
+        public override Task SendGroupAsync(string groupName, string methodName, object[] args)
         {
             if (string.IsNullOrWhiteSpace(groupName)) throw new ArgumentNullException(nameof(groupName));
             if (string.IsNullOrWhiteSpace(methodName)) throw new ArgumentNullException(nameof(methodName));
@@ -115,7 +115,7 @@ namespace SignalR.Orleans
             return group.SendSignalRMessage(methodName, args);
         }
 
-        public override Task InvokeUserAsync(string userId, string methodName, object[] args)
+        public override Task SendUserAsync(string userId, string methodName, object[] args)
         {
             if (string.IsNullOrWhiteSpace(userId)) throw new ArgumentNullException(nameof(userId));
             if (string.IsNullOrWhiteSpace(methodName)) throw new ArgumentNullException(nameof(methodName));
@@ -132,8 +132,7 @@ namespace SignalR.Orleans
 
                 if (connection.User.Identity.IsAuthenticated)
                 {
-                    //TODO: replace `connection.User.Identity.Name` with `connection.UserIdentifier` when next signalr will be published.
-                    var user = this._clusterClient.GetUserGrain(_hubName, connection.User.Identity.Name);
+                    var user = this._clusterClient.GetUserGrain(_hubName, connection.UserIdentifier);
                     await user.Add(_hubName, connection.ConnectionId);
                 }
 
@@ -169,18 +168,12 @@ namespace SignalR.Orleans
             return group.Remove(connectionId);
         }
 
-        private async Task InvokeLocal(HubConnectionContext connection, HubMessage hubMessage)
+        private Task SendLocal(HubConnectionContext connection, HubInvocationMessage hubMessage)
         {
-            while (await connection.Output.WaitToWriteAsync())
-            {
-                if (connection.Output.TryWrite(hubMessage))
-                {
-                    break;
-                }
-            }
+            return connection.WriteAsync(hubMessage);
         }
 
-        private Task InvokeExternal(string connectionId, object hubMessage)
+        private Task SendExternal(string connectionId, object hubMessage)
         {
             var client = this._clusterClient.GetClientGrain(_hubName, connectionId);
             return client.SendMessage(hubMessage);

--- a/src/SignalR.Orleans/OrleansHubLifetimeManager.cs
+++ b/src/SignalR.Orleans/OrleansHubLifetimeManager.cs
@@ -83,13 +83,13 @@ namespace SignalR.Orleans
 
         public override Task InvokeAllAsync(string methodName, object[] args)
         {
-            var message = new InvocationMessage(Guid.NewGuid().ToString(), nonBlocking: true, target: methodName, arguments: args);
+            var message = new InvocationMessage(target: methodName, argumentBindingException: null, arguments: args);
             return this._allStream.OnNextAsync(new AllMessage { Payload = message });
         }
 
         public override Task InvokeAllExceptAsync(string methodName, object[] args, IReadOnlyList<string> excludedIds)
         {
-            var message = new InvocationMessage(Guid.NewGuid().ToString(), nonBlocking: true, target: methodName, arguments: args);
+            var message = new InvocationMessage(target: methodName, argumentBindingException: null, arguments: args);
             return this._allStream.OnNextAsync(new AllMessage { Payload = message, ExcludedIds = excludedIds });
         }
 
@@ -98,7 +98,7 @@ namespace SignalR.Orleans
             if (string.IsNullOrWhiteSpace(connectionId)) throw new ArgumentNullException(nameof(connectionId));
             if (string.IsNullOrWhiteSpace(methodName)) throw new ArgumentNullException(nameof(methodName));
 
-            var message = new InvocationMessage(Guid.NewGuid().ToString(), nonBlocking: true, target: methodName, arguments: args);
+            var message = new InvocationMessage(target: methodName, argumentBindingException: null, arguments: args);
 
             var connection = this._connections[connectionId];
             if (connection != null) return InvokeLocal(connection, message);

--- a/src/SignalR.Orleans/SignalR.Orleans.csproj
+++ b/src/SignalR.Orleans/SignalR.Orleans.csproj
@@ -23,7 +23,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Core" Version="1.0.0-alpha2-final" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Core" Version="1.0.0-preview1-final" />
     <PackageReference Include="Microsoft.Orleans.Core" Version="2.0.0" />
     <PackageReference Include="Microsoft.Orleans.OrleansProviders" Version="2.0.0" />
     <PackageReference Include="Microsoft.Orleans.OrleansCodeGenerator.Build" Version="2.0.0" />

--- a/test/SignalR.Orleans.Tests/OrleansHubLifetimeManagerTests.cs
+++ b/test/SignalR.Orleans.Tests/OrleansHubLifetimeManagerTests.cs
@@ -38,7 +38,7 @@ namespace SignalR.Orleans.Tests
                 await manager.OnConnectedAsync(connection1);
                 await manager.OnConnectedAsync(connection2);
 
-                await manager.InvokeAllAsync("Hello", new object[] { "World" });
+                await manager.SendAllAsync("Hello", new object[] { "World" });
 
                 AssertMessage(output1);
                 AssertMessage(output2);
@@ -63,7 +63,7 @@ namespace SignalR.Orleans.Tests
 
                 await manager.OnDisconnectedAsync(connection2);
 
-                await manager.InvokeAllAsync("Hello", new object[] { "World" });
+                await manager.SendAllAsync("Hello", new object[] { "World" });
 
                 AssertMessage(output1);
 
@@ -89,7 +89,7 @@ namespace SignalR.Orleans.Tests
 
                 await manager.AddGroupAsync(connection1.ConnectionId, "gunit");
 
-                await manager.InvokeGroupAsync("gunit", "Hello", new object[] { "World" });
+                await manager.SendGroupAsync("gunit", "Hello", new object[] { "World" });
 
                 AssertMessage(output1);
 
@@ -108,7 +108,7 @@ namespace SignalR.Orleans.Tests
 
                 await manager.OnConnectedAsync(connection);
 
-                await manager.InvokeConnectionAsync(connection.ConnectionId, "Hello", new object[] { "World" });
+                await manager.SendConnectionAsync(connection.ConnectionId, "Hello", new object[] { "World" });
 
                 AssertMessage(output);
             }
@@ -121,14 +121,14 @@ namespace SignalR.Orleans.Tests
             var grain = this._fixture.Client.GetClientGrain("MyHub", invalidConnection);
             await grain.OnConnect(Guid.NewGuid(), "MyHub", invalidConnection);
             var manager = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), this._fixture.Client);
-            await manager.InvokeConnectionAsync(invalidConnection, "Hello", new object[] { "World" });
+            await manager.SendConnectionAsync(invalidConnection, "Hello", new object[] { "World" });
         }
 
         [Fact]
         public async Task InvokeConnectionAsync_OnNonExistentConnection_WithoutCalling_OnConnect_ThrowsException()
         {
             var manager = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), this._fixture.Client);
-            await Assert.ThrowsAsync<InvalidOperationException>(() => manager.InvokeConnectionAsync("NotARealConnectionIdV2", "Hello", new object[] { "World" }));
+            await Assert.ThrowsAsync<InvalidOperationException>(() => manager.SendConnectionAsync("NotARealConnectionIdV2", "Hello", new object[] { "World" }));
         }
 
         [Fact]
@@ -149,7 +149,7 @@ namespace SignalR.Orleans.Tests
                 await manager1.OnConnectedAsync(connection1);
                 await manager2.OnConnectedAsync(connection2);
 
-                await manager1.InvokeAllAsync("Hello", new object[] { "World" });
+                await manager1.SendAllAsync("Hello", new object[] { "World" });
 
                 AssertMessage(output1);
                 AssertMessage(output2);
@@ -176,7 +176,7 @@ namespace SignalR.Orleans.Tests
 
                 await manager2.OnDisconnectedAsync(connection2);
 
-                await manager2.InvokeAllAsync("Hello", new object[] { "World" });
+                await manager2.SendAllAsync("Hello", new object[] { "World" });
 
                 AssertMessage(output1);
 
@@ -198,7 +198,7 @@ namespace SignalR.Orleans.Tests
 
                 await manager1.OnConnectedAsync(connection);
 
-                await manager2.InvokeConnectionAsync(connection.ConnectionId, "Hello", new object[] { "World" });
+                await manager2.SendConnectionAsync(connection.ConnectionId, "Hello", new object[] { "World" });
 
                 AssertMessage(output);
             }
@@ -220,7 +220,7 @@ namespace SignalR.Orleans.Tests
 
                 await manager1.AddGroupAsync(connection.ConnectionId, "tupac");
 
-                await manager2.InvokeGroupAsync("tupac", "Hello", new object[] { "World" });
+                await manager2.SendGroupAsync("tupac", "Hello", new object[] { "World" });
 
                 AssertMessage(output);
             }
@@ -300,7 +300,7 @@ namespace SignalR.Orleans.Tests
 
                 await manager2.AddGroupAsync(connection.ConnectionId, "ice-cube");
 
-                await manager2.InvokeGroupAsync("ice-cube", "Hello", new object[] { "World" });
+                await manager2.SendGroupAsync("ice-cube", "Hello", new object[] { "World" });
 
                 AssertMessage(output);
             }
@@ -345,7 +345,7 @@ namespace SignalR.Orleans.Tests
                 await manager1.AddGroupAsync(connection.ConnectionId, "easye");
                 await manager2.AddGroupAsync(connection.ConnectionId, "easye");
 
-                await manager2.InvokeGroupAsync("easye", "Hello", new object[] { "World" });
+                await manager2.SendGroupAsync("easye", "Hello", new object[] { "World" });
 
                 AssertMessage(output);
                 Assert.False(output.In.TryRead(out var item));
@@ -368,13 +368,13 @@ namespace SignalR.Orleans.Tests
 
                 await manager1.AddGroupAsync(connection.ConnectionId, "snoop");
 
-                await manager2.InvokeGroupAsync("snoop", "Hello", new object[] { "World" });
+                await manager2.SendGroupAsync("snoop", "Hello", new object[] { "World" });
 
                 AssertMessage(output);
 
                 await manager2.RemoveGroupAsync(connection.ConnectionId, "snoop");
 
-                await manager2.InvokeGroupAsync("snoop", "Hello", new object[] { "World" });
+                await manager2.SendGroupAsync("snoop", "Hello", new object[] { "World" });
 
                 Assert.False(output.In.TryRead(out var item));
             }
@@ -396,7 +396,7 @@ namespace SignalR.Orleans.Tests
                 await manager1.OnConnectedAsync(connection);
                 await manager2.OnConnectedAsync(connection);
 
-                await manager1.InvokeConnectionAsync(connection.ConnectionId, "Hello", new object[] { "World" });
+                await manager1.SendConnectionAsync(connection.ConnectionId, "Hello", new object[] { "World" });
 
                 AssertMessage(output);
                 Assert.False(output.In.TryRead(out var item));
@@ -426,7 +426,7 @@ namespace SignalR.Orleans.Tests
                 await manager2.OnConnectedAsync(connection2);
                 await manager3.OnConnectedAsync(connection3);
 
-                await manager1.InvokeAllAsync("Hello", new object[] { "World" });
+                await manager1.SendAllAsync("Hello", new object[] { "World" });
 
                 AssertMessage(output1);
                 AssertMessage(output2);

--- a/test/SignalR.Orleans.Tests/OrleansHubLifetimeManagerTests.cs
+++ b/test/SignalR.Orleans.Tests/OrleansHubLifetimeManagerTests.cs
@@ -34,8 +34,8 @@ namespace SignalR.Orleans.Tests
             using (var client2 = new TestClient())
             {
                 var manager = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), this._fixture.Client);
-                var connection1 = Create(client1.Connection);
-                var connection2 = Create(client2.Connection);
+                var connection1 = CreateHubConnectionContext(client1.Connection);
+                var connection2 = CreateHubConnectionContext(client2.Connection);
 
                 await manager.OnConnectedAsync(connection1);
                 await manager.OnConnectedAsync(connection2);
@@ -57,8 +57,8 @@ namespace SignalR.Orleans.Tests
             using (var client2 = new TestClient())
             {
                 var manager = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), this._fixture.Client);
-                var connection1 = Create(client1.Connection);
-                var connection2 = Create(client2.Connection);
+                var connection1 = CreateHubConnectionContext(client1.Connection);
+                var connection2 = CreateHubConnectionContext(client2.Connection);
 
                 await manager.OnConnectedAsync(connection1);
                 await manager.OnConnectedAsync(connection2);
@@ -83,8 +83,8 @@ namespace SignalR.Orleans.Tests
             using (var client2 = new TestClient())
             {
                 var manager = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), this._fixture.Client);
-                var connection1 = Create(client1.Connection);
-                var connection2 = Create(client2.Connection);
+                var connection1 = CreateHubConnectionContext(client1.Connection);
+                var connection2 = CreateHubConnectionContext(client2.Connection);
 
                 await manager.OnConnectedAsync(connection1);
                 await manager.OnConnectedAsync(connection2);
@@ -108,7 +108,7 @@ namespace SignalR.Orleans.Tests
             using (var client = new TestClient())
             {
                 var manager = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), this._fixture.Client);
-                var connection = Create(client.Connection);
+                var connection = CreateHubConnectionContext(client.Connection);
 
                 await manager.OnConnectedAsync(connection);
 
@@ -146,8 +146,8 @@ namespace SignalR.Orleans.Tests
             using (var client1 = new TestClient())
             using (var client2 = new TestClient())
             {
-                var connection1 = Create(client1.Connection);
-                var connection2 = Create(client2.Connection);
+                var connection1 = CreateHubConnectionContext(client1.Connection);
+                var connection2 = CreateHubConnectionContext(client2.Connection);
 
                 await manager1.OnConnectedAsync(connection1);
                 await manager2.OnConnectedAsync(connection2);
@@ -171,8 +171,8 @@ namespace SignalR.Orleans.Tests
             using (var client1 = new TestClient())
             using (var client2 = new TestClient())
             {
-                var connection1 = Create(client1.Connection);
-                var connection2 = Create(client2.Connection);
+                var connection1 = CreateHubConnectionContext(client1.Connection);
+                var connection2 = CreateHubConnectionContext(client2.Connection);
 
                 await manager1.OnConnectedAsync(connection1);
                 await manager2.OnConnectedAsync(connection2);
@@ -198,7 +198,7 @@ namespace SignalR.Orleans.Tests
 
             using (var client = new TestClient())
             {
-                var connection = Create(client.Connection);
+                var connection = CreateHubConnectionContext(client.Connection);
 
                 await manager1.OnConnectedAsync(connection);
 
@@ -218,7 +218,7 @@ namespace SignalR.Orleans.Tests
 
             using (var client = new TestClient())
             {
-                var connection = Create(client.Connection);
+                var connection = CreateHubConnectionContext(client.Connection);
 
                 await manager1.OnConnectedAsync(connection);
 
@@ -239,7 +239,7 @@ namespace SignalR.Orleans.Tests
 
             using (var client = new TestClient())
             {
-                var connection = Create(client.Connection);
+                var connection = CreateHubConnectionContext(client.Connection);
 
                 await manager.OnConnectedAsync(connection);
 
@@ -262,7 +262,7 @@ namespace SignalR.Orleans.Tests
 
             using (var client = new TestClient())
             {
-                var connection = Create(client.Connection);
+                var connection = CreateHubConnectionContext(client.Connection);
 
                 await manager.OnConnectedAsync(connection);
 
@@ -280,7 +280,7 @@ namespace SignalR.Orleans.Tests
 
             using (var client = new TestClient())
             {
-                var connection = Create(client.Connection);
+                var connection = CreateHubConnectionContext(client.Connection);
 
                 await manager1.OnConnectedAsync(connection);
 
@@ -298,7 +298,7 @@ namespace SignalR.Orleans.Tests
 
             using (var client = new TestClient())
             {
-                var connection = Create(client.Connection);
+                var connection = CreateHubConnectionContext(client.Connection);
 
                 await manager1.OnConnectedAsync(connection);
 
@@ -319,7 +319,7 @@ namespace SignalR.Orleans.Tests
 
             using (var client = new TestClient())
             {
-                var connection = Create(client.Connection);
+                var connection = CreateHubConnectionContext(client.Connection);
 
                 await manager.OnConnectedAsync(connection);
 
@@ -342,7 +342,7 @@ namespace SignalR.Orleans.Tests
 
             using (var client = new TestClient())
             {
-                var connection = Create(client.Connection);
+                var connection = CreateHubConnectionContext(client.Connection);
 
                 await manager1.OnConnectedAsync(connection);
 
@@ -366,7 +366,7 @@ namespace SignalR.Orleans.Tests
 
             using (var client = new TestClient())
             {
-                var connection = Create(client.Connection);
+                var connection = CreateHubConnectionContext(client.Connection);
 
                 await manager1.OnConnectedAsync(connection);
 
@@ -394,7 +394,7 @@ namespace SignalR.Orleans.Tests
 
             using (var client = new TestClient())
             {
-                var connection = Create(client.Connection);
+                var connection = CreateHubConnectionContext(client.Connection);
 
                 // Add connection to both "servers" to see if connection receives message twice
                 await manager1.OnConnectedAsync(connection);
@@ -420,9 +420,9 @@ namespace SignalR.Orleans.Tests
             using (var client2 = new TestClient())
             using (var client3 = new TestClient())
             {
-                var connection1 = Create(client1.Connection);
-                var connection2 = Create(client2.Connection);
-                var connection3 = Create(client3.Connection);
+                var connection1 = CreateHubConnectionContext(client1.Connection);
+                var connection2 = CreateHubConnectionContext(client2.Connection);
+                var connection3 = CreateHubConnectionContext(client3.Connection);
 
                 await manager1.OnConnectedAsync(connection1);
                 await manager2.OnConnectedAsync(connection2);
@@ -450,7 +450,7 @@ namespace SignalR.Orleans.Tests
             Assert.Equal("World", (string)message.Arguments[0]);
         }
 
-        public static HubConnectionContext Create(DefaultConnectionContext connection)
+        public static HubConnectionContext CreateHubConnectionContext(DefaultConnectionContext connection)
         {
             var context = new HubConnectionContext(connection, TimeSpan.FromSeconds(15), NullLoggerFactory.Instance);
             context.ProtocolReaderWriter = new HubProtocolReaderWriter(new JsonHubProtocol(), new PassThroughEncoder());

--- a/test/SignalR.Orleans.Tests/OrleansHubLifetimeManagerTests.cs
+++ b/test/SignalR.Orleans.Tests/OrleansHubLifetimeManagerTests.cs
@@ -82,12 +82,9 @@ namespace SignalR.Orleans.Tests
             using (var client1 = new TestClient())
             using (var client2 = new TestClient())
             {
-                var output1 = Channel.CreateUnbounded<HubMessage>();
-                var output2 = Channel.CreateUnbounded<HubMessage>();
-
                 var manager = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), this._fixture.Client);
-                var connection1 = new HubConnectionContext(output1, client1.Connection);
-                var connection2 = new HubConnectionContext(output2, client2.Connection);
+                var connection1 = Create(client1.Connection);
+                var connection2 = Create(client2.Connection);
 
                 await manager.OnConnectedAsync(connection1);
                 await manager.OnConnectedAsync(connection2);
@@ -96,9 +93,9 @@ namespace SignalR.Orleans.Tests
 
                 await manager.SendGroupAsync("gunit", "Hello", new object[] { "World" });
 
-                AssertMessage(output1);
+                AssertMessage(client1.TryRead());
 
-                Assert.False(output2.In.TryRead(out var item));
+                Assert.Null(client2.TryRead());
             }
         }
 
@@ -107,15 +104,14 @@ namespace SignalR.Orleans.Tests
         {
             using (var client = new TestClient())
             {
-                var output = Channel.CreateUnbounded<HubMessage>();
                 var manager = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), this._fixture.Client);
-                var connection = new HubConnectionContext(output, client.Connection);
+                var connection = Create(client.Connection);
 
                 await manager.OnConnectedAsync(connection);
 
                 await manager.SendConnectionAsync(connection.ConnectionId, "Hello", new object[] { "World" });
 
-                AssertMessage(output);
+                AssertMessage(client.TryRead());
             }
         }
 
@@ -145,19 +141,16 @@ namespace SignalR.Orleans.Tests
             using (var client1 = new TestClient())
             using (var client2 = new TestClient())
             {
-                var output1 = Channel.CreateUnbounded<HubMessage>();
-                var output2 = Channel.CreateUnbounded<HubMessage>();
-
-                var connection1 = new HubConnectionContext(output1, client1.Connection);
-                var connection2 = new HubConnectionContext(output2, client2.Connection);
+                var connection1 = Create(client1.Connection);
+                var connection2 = Create(client2.Connection);
 
                 await manager1.OnConnectedAsync(connection1);
                 await manager2.OnConnectedAsync(connection2);
 
                 await manager1.SendAllAsync("Hello", new object[] { "World" });
 
-                AssertMessage(output1);
-                AssertMessage(output2);
+                AssertMessage(client1.TryRead());
+                AssertMessage(client2.TryRead());
             }
         }
 
@@ -170,11 +163,8 @@ namespace SignalR.Orleans.Tests
             using (var client1 = new TestClient())
             using (var client2 = new TestClient())
             {
-                var output1 = Channel.CreateUnbounded<HubMessage>();
-                var output2 = Channel.CreateUnbounded<HubMessage>();
-
-                var connection1 = new HubConnectionContext(output1, client1.Connection);
-                var connection2 = new HubConnectionContext(output2, client2.Connection);
+                var connection1 = Create(client1.Connection);
+                var connection2 = Create(client2.Connection);
 
                 await manager1.OnConnectedAsync(connection1);
                 await manager2.OnConnectedAsync(connection2);
@@ -183,9 +173,9 @@ namespace SignalR.Orleans.Tests
 
                 await manager2.SendAllAsync("Hello", new object[] { "World" });
 
-                AssertMessage(output1);
+                AssertMessage(client1.TryRead());
 
-                Assert.False(output2.In.TryRead(out var item));
+                Assert.Null(client2.TryRead());
             }
         }
 
@@ -197,15 +187,13 @@ namespace SignalR.Orleans.Tests
 
             using (var client = new TestClient())
             {
-                var output = Channel.CreateUnbounded<HubMessage>();
-
-                var connection = new HubConnectionContext(output, client.Connection);
+                var connection = Create(client.Connection);
 
                 await manager1.OnConnectedAsync(connection);
 
                 await manager2.SendConnectionAsync(connection.ConnectionId, "Hello", new object[] { "World" });
 
-                AssertMessage(output);
+                AssertMessage(client.TryRead());
             }
         }
 
@@ -217,9 +205,7 @@ namespace SignalR.Orleans.Tests
 
             using (var client = new TestClient())
             {
-                var output = Channel.CreateUnbounded<HubMessage>();
-
-                var connection = new HubConnectionContext(output, client.Connection);
+                var connection = Create(client.Connection);
 
                 await manager1.OnConnectedAsync(connection);
 
@@ -227,7 +213,7 @@ namespace SignalR.Orleans.Tests
 
                 await manager2.SendGroupAsync("tupac", "Hello", new object[] { "World" });
 
-                AssertMessage(output);
+                AssertMessage(client.TryRead());
             }
         }
 
@@ -238,9 +224,7 @@ namespace SignalR.Orleans.Tests
 
             using (var client = new TestClient())
             {
-                var output = Channel.CreateUnbounded<HubMessage>();
-
-                var connection = new HubConnectionContext(output, client.Connection);
+                var connection = Create(client.Connection);
 
                 await manager.OnConnectedAsync(connection);
 
@@ -261,9 +245,7 @@ namespace SignalR.Orleans.Tests
 
             using (var client = new TestClient())
             {
-                var output = Channel.CreateUnbounded<HubMessage>();
-
-                var connection = new HubConnectionContext(output, client.Connection);
+                var connection = Create(client.Connection);
 
                 await manager.OnConnectedAsync(connection);
 
@@ -279,9 +261,7 @@ namespace SignalR.Orleans.Tests
 
             using (var client = new TestClient())
             {
-                var output = Channel.CreateUnbounded<HubMessage>();
-
-                var connection = new HubConnectionContext(output, client.Connection);
+                var connection = Create(client.Connection);
 
                 await manager1.OnConnectedAsync(connection);
 
@@ -297,9 +277,7 @@ namespace SignalR.Orleans.Tests
 
             using (var client = new TestClient())
             {
-                var output = Channel.CreateUnbounded<HubMessage>();
-
-                var connection = new HubConnectionContext(output, client.Connection);
+                var connection = Create(client.Connection);
 
                 await manager1.OnConnectedAsync(connection);
 
@@ -307,7 +285,7 @@ namespace SignalR.Orleans.Tests
 
                 await manager2.SendGroupAsync("ice-cube", "Hello", new object[] { "World" });
 
-                AssertMessage(output);
+                AssertMessage(client.TryRead());
             }
         }
 
@@ -318,9 +296,7 @@ namespace SignalR.Orleans.Tests
 
             using (var client = new TestClient())
             {
-                var output = Channel.CreateUnbounded<HubMessage>();
-
-                var connection = new HubConnectionContext(output, client.Connection);
+                var connection = Create(client.Connection);
 
                 await manager.OnConnectedAsync(connection);
 
@@ -341,9 +317,7 @@ namespace SignalR.Orleans.Tests
 
             using (var client = new TestClient())
             {
-                var output = Channel.CreateUnbounded<HubMessage>();
-
-                var connection = new HubConnectionContext(output, client.Connection);
+                var connection = Create(client.Connection);
 
                 await manager1.OnConnectedAsync(connection);
 
@@ -352,8 +326,8 @@ namespace SignalR.Orleans.Tests
 
                 await manager2.SendGroupAsync("easye", "Hello", new object[] { "World" });
 
-                AssertMessage(output);
-                Assert.False(output.In.TryRead(out var item));
+                AssertMessage(client.TryRead());
+                Assert.Null(client.TryRead());
             }
         }
 
@@ -365,9 +339,7 @@ namespace SignalR.Orleans.Tests
 
             using (var client = new TestClient())
             {
-                var output = Channel.CreateUnbounded<HubMessage>();
-
-                var connection = new HubConnectionContext(output, client.Connection);
+                var connection = Create(client.Connection);
 
                 await manager1.OnConnectedAsync(connection);
 
@@ -375,13 +347,13 @@ namespace SignalR.Orleans.Tests
 
                 await manager2.SendGroupAsync("snoop", "Hello", new object[] { "World" });
 
-                AssertMessage(output);
+                AssertMessage(client.TryRead());
 
                 await manager2.RemoveGroupAsync(connection.ConnectionId, "snoop");
 
                 await manager2.SendGroupAsync("snoop", "Hello", new object[] { "World" });
 
-                Assert.False(output.In.TryRead(out var item));
+                Assert.Null(client.TryRead());
             }
         }
 
@@ -393,9 +365,7 @@ namespace SignalR.Orleans.Tests
 
             using (var client = new TestClient())
             {
-                var output = Channel.CreateUnbounded<HubMessage>();
-
-                var connection = new HubConnectionContext(output, client.Connection);
+                var connection = Create(client.Connection);
 
                 // Add connection to both "servers" to see if connection receives message twice
                 await manager1.OnConnectedAsync(connection);
@@ -403,8 +373,8 @@ namespace SignalR.Orleans.Tests
 
                 await manager1.SendConnectionAsync(connection.ConnectionId, "Hello", new object[] { "World" });
 
-                AssertMessage(output);
-                Assert.False(output.In.TryRead(out var item));
+                AssertMessage(client.TryRead());
+                Assert.Null(client.TryRead());
             }
         }
 
@@ -419,13 +389,9 @@ namespace SignalR.Orleans.Tests
             using (var client2 = new TestClient())
             using (var client3 = new TestClient())
             {
-                var output1 = Channel.CreateUnbounded<HubMessage>();
-                var output2 = Channel.CreateUnbounded<HubMessage>();
-                var output3 = Channel.CreateUnbounded<HubMessage>();
-
-                var connection1 = new HubConnectionContext(output1, client1.Connection);
-                var connection2 = new HubConnectionContext(output2, client2.Connection);
-                var connection3 = new HubConnectionContext(output3, client3.Connection);
+                var connection1 = Create(client1.Connection);
+                var connection2 = Create(client2.Connection);
+                var connection3 = Create(client3.Connection);
 
                 await manager1.OnConnectedAsync(connection1);
                 await manager2.OnConnectedAsync(connection2);
@@ -433,9 +399,9 @@ namespace SignalR.Orleans.Tests
 
                 await manager1.SendAllAsync("Hello", new object[] { "World" });
 
-                AssertMessage(output1);
-                AssertMessage(output2);
-                Assert.False(output3.In.TryRead(out var item));
+                AssertMessage(client1.TryRead());
+                AssertMessage(client2.TryRead());
+                Assert.Null(client3.TryRead());
             }
         }
 

--- a/test/SignalR.Orleans.Tests/OrleansHubLifetimeManagerTests.cs
+++ b/test/SignalR.Orleans.Tests/OrleansHubLifetimeManagerTests.cs
@@ -93,6 +93,9 @@ namespace SignalR.Orleans.Tests
 
                 await manager.SendGroupAsync("gunit", "Hello", new object[] { "World" });
 
+                await connection1.DisposeAsync();
+                await connection2.DisposeAsync();
+
                 AssertMessage(client1.TryRead());
 
                 Assert.Null(client2.TryRead());
@@ -110,6 +113,8 @@ namespace SignalR.Orleans.Tests
                 await manager.OnConnectedAsync(connection);
 
                 await manager.SendConnectionAsync(connection.ConnectionId, "Hello", new object[] { "World" });
+
+                await connection.DisposeAsync();
 
                 AssertMessage(client.TryRead());
             }
@@ -149,6 +154,9 @@ namespace SignalR.Orleans.Tests
 
                 await manager1.SendAllAsync("Hello", new object[] { "World" });
 
+                await connection1.DisposeAsync();
+                await connection2.DisposeAsync();
+
                 AssertMessage(client1.TryRead());
                 AssertMessage(client2.TryRead());
             }
@@ -173,6 +181,9 @@ namespace SignalR.Orleans.Tests
 
                 await manager2.SendAllAsync("Hello", new object[] { "World" });
 
+                await connection1.DisposeAsync();
+                await connection2.DisposeAsync();
+
                 AssertMessage(client1.TryRead());
 
                 Assert.Null(client2.TryRead());
@@ -192,6 +203,8 @@ namespace SignalR.Orleans.Tests
                 await manager1.OnConnectedAsync(connection);
 
                 await manager2.SendConnectionAsync(connection.ConnectionId, "Hello", new object[] { "World" });
+
+                await connection.DisposeAsync();
 
                 AssertMessage(client.TryRead());
             }
@@ -213,6 +226,8 @@ namespace SignalR.Orleans.Tests
 
                 await manager2.SendGroupAsync("tupac", "Hello", new object[] { "World" });
 
+                await connection.DisposeAsync();
+
                 AssertMessage(client.TryRead());
             }
         }
@@ -232,6 +247,8 @@ namespace SignalR.Orleans.Tests
 
                 await manager.OnDisconnectedAsync(connection);
 
+                await connection.DisposeAsync();
+
                 var grain = this._fixture.Client.GetGroupGrain("MyHub", "dre");
                 var result = await grain.Count();
                 Assert.Equal(0, result);
@@ -250,6 +267,8 @@ namespace SignalR.Orleans.Tests
                 await manager.OnConnectedAsync(connection);
 
                 await manager.RemoveGroupAsync(connection.ConnectionId, "does-not-exists");
+
+                await connection.DisposeAsync();
             }
         }
 
@@ -266,6 +285,8 @@ namespace SignalR.Orleans.Tests
                 await manager1.OnConnectedAsync(connection);
 
                 await manager2.RemoveGroupAsync(connection.ConnectionId, "does-not-exist-server");
+
+                await connection.DisposeAsync();
             }
         }
 
@@ -285,6 +306,8 @@ namespace SignalR.Orleans.Tests
 
                 await manager2.SendGroupAsync("ice-cube", "Hello", new object[] { "World" });
 
+                await connection.DisposeAsync();
+
                 AssertMessage(client.TryRead());
             }
         }
@@ -302,6 +325,8 @@ namespace SignalR.Orleans.Tests
 
                 await manager.AddGroupAsync(connection.ConnectionId, "dmx");
                 await manager.AddGroupAsync(connection.ConnectionId, "dmx");
+
+                await connection.DisposeAsync();
 
                 var grain = this._fixture.Client.GetGroupGrain("MyHub", "dmx");
                 var result = await grain.Count();
@@ -326,6 +351,8 @@ namespace SignalR.Orleans.Tests
 
                 await manager2.SendGroupAsync("easye", "Hello", new object[] { "World" });
 
+                await connection.DisposeAsync();
+
                 AssertMessage(client.TryRead());
                 Assert.Null(client.TryRead());
             }
@@ -347,11 +374,13 @@ namespace SignalR.Orleans.Tests
 
                 await manager2.SendGroupAsync("snoop", "Hello", new object[] { "World" });
 
-                AssertMessage(client.TryRead());
+                AssertMessage(await client.ReadAsync());
 
                 await manager2.RemoveGroupAsync(connection.ConnectionId, "snoop");
 
                 await manager2.SendGroupAsync("snoop", "Hello", new object[] { "World" });
+
+                await connection.DisposeAsync();
 
                 Assert.Null(client.TryRead());
             }
@@ -372,6 +401,8 @@ namespace SignalR.Orleans.Tests
                 await manager2.OnConnectedAsync(connection);
 
                 await manager1.SendConnectionAsync(connection.ConnectionId, "Hello", new object[] { "World" });
+
+                await connection.DisposeAsync();
 
                 AssertMessage(client.TryRead());
                 Assert.Null(client.TryRead());
@@ -398,6 +429,10 @@ namespace SignalR.Orleans.Tests
                 await manager3.OnConnectedAsync(connection3);
 
                 await manager1.SendAllAsync("Hello", new object[] { "World" });
+
+                await connection1.DisposeAsync();
+                await connection2.DisposeAsync();
+                await connection3.DisposeAsync();
 
                 AssertMessage(client1.TryRead());
                 AssertMessage(client2.TryRead());

--- a/test/SignalR.Orleans.Tests/SignalR.Orleans.Tests.csproj
+++ b/test/SignalR.Orleans.Tests/SignalR.Orleans.Tests.csproj
@@ -10,9 +10,9 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.2" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Core" Version="1.0.0-alpha2-final" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Core" Version="1.0.0-preview1-final" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.0.0-alpha2-final" />
-    <PackageReference Include="Microsoft.AspNetCore.Sockets" Version="1.0.0-alpha2-final" />
+    <PackageReference Include="Microsoft.AspNetCore.Sockets" Version="1.0.0-preview1-final" />
     <PackageReference Include="Microsoft.Orleans.Core" Version="2.0.0" />
     <PackageReference Include="Microsoft.Orleans.OrleansProviders" Version="2.0.0" />
     <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="2.0.0" />

--- a/test/SignalR.Orleans.Tests/TestClient.cs
+++ b/test/SignalR.Orleans.Tests/TestClient.cs
@@ -22,8 +22,8 @@ namespace SignalR.Orleans.Tests
         private static int _id;
         private readonly HubProtocolReaderWriter _protocolReaderWriter;
         private readonly IInvocationBinder _invocationBinder;
-        private CancellationTokenSource _cts;
-        private ChannelConnection<byte[]> _transport;
+        private readonly CancellationTokenSource _cts;
+        private readonly ChannelConnection<byte[]> _transport;
 
         public DefaultConnectionContext Connection { get; }
         public Channel<byte[]> Application { get; }

--- a/test/SignalR.Orleans.Tests/TestClient.cs
+++ b/test/SignalR.Orleans.Tests/TestClient.cs
@@ -1,18 +1,19 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.AspNetCore.SignalR.Internal;
-using Microsoft.AspNetCore.SignalR.Internal.Encoders;
-using Microsoft.AspNetCore.SignalR.Internal.Protocol;
-using Microsoft.AspNetCore.Sockets;
-using Microsoft.AspNetCore.Sockets.Internal;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Threading.Tasks.Channels;
+using System.Threading.Channels;
+using Microsoft.AspNetCore.SignalR.Internal;
+using Microsoft.AspNetCore.SignalR.Internal.Encoders;
+using Microsoft.AspNetCore.SignalR.Internal.Protocol;
+using Microsoft.AspNetCore.Sockets;
+using Microsoft.AspNetCore.Sockets.Internal;
+using Newtonsoft.Json;
 
 namespace SignalR.Orleans.Tests
 {
@@ -21,9 +22,8 @@ namespace SignalR.Orleans.Tests
         private static int _id;
         private readonly HubProtocolReaderWriter _protocolReaderWriter;
         private readonly IInvocationBinder _invocationBinder;
-        private readonly CancellationTokenSource _cts;
-        private readonly ChannelConnection<byte[]> _transport;
-
+        private CancellationTokenSource _cts;
+        private ChannelConnection<byte[]> _transport;
 
         public DefaultConnectionContext Connection { get; }
         public Channel<byte[]> Application { get; }
@@ -31,7 +31,7 @@ namespace SignalR.Orleans.Tests
 
         public TestClient(bool synchronousCallbacks = false, IHubProtocol protocol = null, IInvocationBinder invocationBinder = null, bool addClaimId = false)
         {
-            var options = new ChannelOptimizations { AllowSynchronousContinuations = synchronousCallbacks };
+            var options = new UnboundedChannelOptions { AllowSynchronousContinuations = synchronousCallbacks };
             var transportToApplication = Channel.CreateUnbounded<byte[]>(options);
             var applicationToTransport = Channel.CreateUnbounded<byte[]>(options);
 
@@ -41,7 +41,7 @@ namespace SignalR.Orleans.Tests
             Connection = new DefaultConnectionContext(Guid.NewGuid().ToString(), _transport, Application);
 
             var claimValue = Interlocked.Increment(ref _id).ToString();
-            var claims = new List<Claim> { new Claim(ClaimTypes.Name, claimValue) };
+            var claims = new List<Claim>{ new Claim(ClaimTypes.Name, claimValue) };
             if (addClaimId)
             {
                 claims.Add(new Claim(ClaimTypes.NameIdentifier, claimValue));
@@ -59,13 +59,13 @@ namespace SignalR.Orleans.Tests
             using (var memoryStream = new MemoryStream())
             {
                 NegotiationProtocol.WriteMessage(new NegotiationMessage(protocol.Name), memoryStream);
-                Application.Out.TryWrite(memoryStream.ToArray());
+                Application.Writer.TryWrite(memoryStream.ToArray());
             }
         }
 
         public async Task<IList<HubMessage>> StreamAsync(string methodName, params object[] args)
         {
-            var invocationId = await SendInvocationAsync(methodName, nonBlocking: false, args: args);
+            var invocationId = await SendStreamInvocationAsync(methodName, args);
 
             var messages = new List<HubMessage>();
             while (true)
@@ -77,7 +77,7 @@ namespace SignalR.Orleans.Tests
                     throw new InvalidOperationException("Connection aborted!");
                 }
 
-                if (!string.Equals(message.InvocationId, invocationId))
+                if (message is HubInvocationMessage hubInvocationMessage && !string.Equals(hubInvocationMessage.InvocationId, invocationId))
                 {
                     throw new NotSupportedException("TestClient does not support multiple outgoing invocations!");
                 }
@@ -88,9 +88,8 @@ namespace SignalR.Orleans.Tests
                         messages.Add(message);
                         break;
                     case CompletionMessage _:
-                    // case StreamCompletionMessage _:
-                    //     messages.Add(message);
-                    //     return messages;
+                        messages.Add(message);
+                        return messages;
                     default:
                         throw new NotSupportedException("TestClient does not support receiving invocations!");
                 }
@@ -110,7 +109,7 @@ namespace SignalR.Orleans.Tests
                     throw new InvalidOperationException("Connection aborted!");
                 }
 
-                if (!string.Equals(message.InvocationId, invocationId))
+                if (message is HubInvocationMessage hubInvocationMessage && !string.Equals(hubInvocationMessage.InvocationId, invocationId))
                 {
                     throw new NotSupportedException("TestClient does not support multiple outgoing invocations!");
                 }
@@ -121,6 +120,9 @@ namespace SignalR.Orleans.Tests
                         throw new NotSupportedException("Use 'StreamAsync' to call a streaming method");
                     case CompletionMessage completion:
                         return completion;
+                    case PingMessage _:
+                        // Pings are ignored
+                        break;
                     default:
                         throw new NotSupportedException("TestClient does not support receiving invocations!");
                 }
@@ -135,14 +137,21 @@ namespace SignalR.Orleans.Tests
         public Task<string> SendInvocationAsync(string methodName, bool nonBlocking, params object[] args)
         {
             var invocationId = GetInvocationId();
-            return SendHubMessageAsync(new InvocationMessage(invocationId, nonBlocking, methodName, args));
+            return SendHubMessageAsync(new InvocationMessage(invocationId, methodName, null, args));
+        }
+
+        public Task<string> SendStreamInvocationAsync(string methodName, params object[] args)
+        {
+            var invocationId = GetInvocationId();
+            return SendHubMessageAsync(new StreamInvocationMessage(invocationId, methodName,
+                argumentBindingException: null, arguments: args));
         }
 
         public async Task<string> SendHubMessageAsync(HubMessage message)
         {
             var payload = _protocolReaderWriter.WriteMessage(message);
-            await Application.Out.WriteAsync(payload);
-            return message.InvocationId;
+            await Application.Writer.WriteAsync(payload);
+            return message is HubInvocationMessage hubMessage ? hubMessage.InvocationId : null;
         }
 
         public async Task<HubMessage> ReadAsync()
@@ -153,7 +162,7 @@ namespace SignalR.Orleans.Tests
 
                 if (message == null)
                 {
-                    if (!await Application.In.WaitToReadAsync())
+                    if (!await Application.Reader.WaitToReadAsync())
                     {
                         return null;
                     }
@@ -167,7 +176,7 @@ namespace SignalR.Orleans.Tests
 
         public HubMessage TryRead()
         {
-            if (Application.In.TryRead(out var buffer) &&
+            if (Application.Reader.TryRead(out var buffer) &&
                 _protocolReaderWriter.ReadMessages(buffer, _invocationBinder, out var messages))
             {
                 return messages[0];


### PR DESCRIPTION
Hello,

I wanted to play & learn with SignalR.Orleans and upgrade Signalr to 1.0.0-preview1-final. I don't expect this to be pulled without first discussing these points with people more familiar with the project.

- [x] I am unsure when the function `SendGroupExceptAsync` was added to SignalR core. And unsure how best to implement it here. I added it as a function to `GroupGrain` instead of `ConnectionGrain`, not sure which is best.
- [x] I used Task.WhenAll to implement the new plural methods ` SendGroups`, `SendUsers` etc... I am unsure if we want to take the more involved approach using a [dispatcher](https://github.com/OrleansContrib/DesignPatterns/blob/master/Dispatcher.md) edit: or even if a dispatcher would improve performance at all.
- [ ] I have made it pass unit test, but unsure what local testing needs to be performed first. So please test for regressions on your end.

