### PR TITLE
refactor(silo extension): now allow consumer to configure builder

### DIFF
--- a/src/SignalR.Orleans/Constants.cs
+++ b/src/SignalR.Orleans/Constants.cs
@@ -4,7 +4,9 @@ namespace SignalR.Orleans
 {
     public static class Constants
     {
+        public const string PUBSUB_PROVIDER = "PubSubStore";
         public const string STORAGE_PROVIDER = "ORLEANS_SIGNALR_STORAGE_PROVIDER";
+
         public const string SERVERS_STREAM = "SERVERS_STREAM";
         public const string STREAM_PROVIDER = "ORLEANS_SIGNALR_STREAM_PROVIDER";
         public static readonly Guid CLIENT_DISCONNECT_STREAM_ID = Guid.Parse("bdcff7e7-3734-48ab-8599-17d915011b85");

--- a/src/SignalR.Orleans/Extensions.cs
+++ b/src/SignalR.Orleans/Extensions.cs
@@ -9,22 +9,33 @@ namespace Microsoft.Extensions.DependencyInjection
 {
     public static class OrleansServerExtensions
     {
-        public static ISiloHostBuilder UseSignalR(this ISiloHostBuilder builder, bool useFireAndForgetDelivery = false)
+        public static ISiloHostBuilder UseSignalR(this ISiloHostBuilder builder, SignalrServerConfig config = null)
         {
-            try { builder = builder.AddMemoryGrainStorage("PubSubStore"); }
+            if (config == null)
+                config = new SignalrServerConfig();
+
+            config.ConfigureBuilder?.Invoke(builder, new HostBuilderConfig());
+
+            try { builder.AddMemoryGrainStorage(Constants.PUBSUB_PROVIDER); }
             catch { /** PubSubStore was already added. Do nothing. **/ }
 
-            return builder.AddMemoryGrainStorage(Constants.STORAGE_PROVIDER)
-                .AddSimpleMessageStreamProvider(Constants.STREAM_PROVIDER, opt => opt.FireAndForgetDelivery = useFireAndForgetDelivery)
+            try { builder.AddMemoryGrainStorage(Constants.STORAGE_PROVIDER); }
+            catch { /** Grain storage provider was already added. Do nothing. **/ }
+
+            return builder
+                .AddSimpleMessageStreamProvider(Constants.STREAM_PROVIDER, opt => opt.FireAndForgetDelivery = config.UseFireAndForgetDelivery)
                 .ConfigureApplicationParts(parts => parts.AddApplicationPart(typeof(ClientGrain).Assembly).WithReferences());
         }
     }
 
     public static class OrleansClientExtensions
     {
-        public static IClientBuilder UseSignalR(this IClientBuilder builder, bool useFireAndForgetDelivery = false)
+        public static IClientBuilder UseSignalR(this IClientBuilder builder, SignalrClientConfig config = null)
         {
-            return builder.AddSimpleMessageStreamProvider(Constants.STREAM_PROVIDER, opt => opt.FireAndForgetDelivery = useFireAndForgetDelivery)
+            if (config == null)
+                config = new SignalrClientConfig();
+
+            return builder.AddSimpleMessageStreamProvider(Constants.STREAM_PROVIDER, opt => opt.FireAndForgetDelivery = config.UseFireAndForgetDelivery)
                 .ConfigureApplicationParts(parts => parts.AddApplicationPart(typeof(IClientGrain).Assembly).WithReferences());
         }
     }

--- a/src/SignalR.Orleans/SignalrConfig.cs
+++ b/src/SignalR.Orleans/SignalrConfig.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using Orleans.Hosting;
+
+namespace SignalR.Orleans
+{
+    public class HostBuilderConfig
+    {
+        public string StorageProvider { get; } = Constants.STORAGE_PROVIDER;
+        public string PubSubProvider { get; } = Constants.PUBSUB_PROVIDER;
+    }
+
+    public class SignalrServerConfig
+    {
+        public Action<ISiloHostBuilder, HostBuilderConfig> ConfigureProviders { get; set; }
+        public bool UseFireAndForgetDelivery { get; set; }
+    }
+
+    public class SignalrClientConfig
+    {
+        public bool UseFireAndForgetDelivery { get; set; }
+    }
+}

--- a/src/SignalR.Orleans/SignalrConfig.cs
+++ b/src/SignalR.Orleans/SignalrConfig.cs
@@ -11,7 +11,7 @@ namespace SignalR.Orleans
 
     public class SignalrServerConfig
     {
-        public Action<ISiloHostBuilder, HostBuilderConfig> ConfigureProviders { get; set; }
+        public Action<ISiloHostBuilder, HostBuilderConfig> ConfigureBuilder { get; set; }
         public bool UseFireAndForgetDelivery { get; set; }
     }
 


### PR DESCRIPTION
BREAKING CHANGE:
- Orleans Server Extension: `UseSignalR` extension changed optional parameter `useFireAndForgetDelivery` to `SignalrServerConfig`) which contains same default configuration.

- Orleans Client Extension: `UseSignalR` extension changed optional parameter `useFireAndForgetDelivery` to `SignalrClientConfig`) which contains same default configuration.

fix for: https://github.com/OrleansContrib/SignalR.Orleans/issues/54