### PR TITLE
Refactoring and fixes

### DIFF
--- a/src/SignalR.Orleans/Clients/ClientGrain.cs
+++ b/src/SignalR.Orleans/Clients/ClientGrain.cs
@@ -32,6 +32,7 @@ namespace SignalR.Orleans.Clients
             return this._serverStream.OnNextAsync(new ClientMessage { ConnectionId = State.ConnectionId, Payload = message, HubName = State.HubName });
         }
 
+        // todo: remove hubname + connection id + get from PK
         public Task OnConnect(Guid serverId, string hubName, string connectionId)
         {
             this.State.ServerId = serverId;
@@ -53,6 +54,7 @@ namespace SignalR.Orleans.Clients
         }
     }
 
+    // todo: debugger display
     internal class ClientState
     {
         public Guid ServerId { get; set; }

--- a/src/SignalR.Orleans/Clients/ClientGrain.cs
+++ b/src/SignalR.Orleans/Clients/ClientGrain.cs
@@ -35,6 +35,7 @@ namespace SignalR.Orleans.Clients
         // todo: remove hubname + connection id + get from PK
         public Task OnConnect(Guid serverId, string hubName, string connectionId)
         {
+            // todo: can this connect if its already connected?
             this.State.ServerId = serverId;
             this.State.HubName = hubName;
             this.State.ConnectionId = connectionId;

--- a/src/SignalR.Orleans/Clients/ClientGrain.cs
+++ b/src/SignalR.Orleans/Clients/ClientGrain.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.SignalR.Protocol;
 using Orleans;
 using Orleans.Providers;
 using Orleans.Streams;
@@ -37,7 +38,7 @@ namespace SignalR.Orleans.Clients
             return Task.CompletedTask;
         }
 
-        public Task SendMessage(object message)
+        public Task Send(InvocationMessage message)
         {
             if (State.ServerId == Guid.Empty) throw new InvalidOperationException("Client not connected.");
             return _serverStream.OnNextAsync(new ClientMessage { ConnectionId = _keyData.Id, Payload = message, HubName = _keyData.HubName });

--- a/src/SignalR.Orleans/Clients/ClientGrain.cs
+++ b/src/SignalR.Orleans/Clients/ClientGrain.cs
@@ -50,7 +50,7 @@ namespace SignalR.Orleans.Clients
             if (State.ServerId != Guid.Empty)
                 return _serverStream.OnNextAsync(new ClientMessage { ConnectionId = _keyData.Id, Payload = message, HubName = _keyData.HubName });
 
-            _logger.LogError("Client not connected for connectionId '{connectionId}' and hub '{hubName}' ", _keyData.Id, _keyData.HubName);
+            _logger.LogError("Client not connected for connectionId '{connectionId}' and hub '{hubName}'", _keyData.Id, _keyData.HubName);
             return Task.CompletedTask;
         }
 

--- a/src/SignalR.Orleans/Clients/ClientMessage.cs
+++ b/src/SignalR.Orleans/Clients/ClientMessage.cs
@@ -2,7 +2,6 @@ using Microsoft.AspNetCore.SignalR.Protocol;
 
 namespace SignalR.Orleans.Clients
 {
-    // todo: debugger display
     public class ClientMessage
     {
         public string HubName { get; set; }

--- a/src/SignalR.Orleans/Clients/ClientMessage.cs
+++ b/src/SignalR.Orleans/Clients/ClientMessage.cs
@@ -1,3 +1,5 @@
+using Microsoft.AspNetCore.SignalR.Protocol;
+
 namespace SignalR.Orleans.Clients
 {
     // todo: debugger display
@@ -5,6 +7,6 @@ namespace SignalR.Orleans.Clients
     {
         public string HubName { get; set; }
         public string ConnectionId { get; set; }
-        public object Payload { get; set; } // todo: can this be typed InvocationMessage?
+        public InvocationMessage Payload { get; set; }
     }
 }

--- a/src/SignalR.Orleans/Clients/ClientMessage.cs
+++ b/src/SignalR.Orleans/Clients/ClientMessage.cs
@@ -1,9 +1,10 @@
 namespace SignalR.Orleans.Clients
 {
+    // todo: debugger display
     public class ClientMessage
     {
         public string HubName { get; set; }
         public string ConnectionId { get; set; }
-        public object Payload { get; set; }
+        public object Payload { get; set; } // todo: can this be typed InvocationMessage?
     }
 }

--- a/src/SignalR.Orleans/Clients/IClientGrain.cs
+++ b/src/SignalR.Orleans/Clients/IClientGrain.cs
@@ -1,12 +1,12 @@
 using System;
 using System.Threading.Tasks;
 using Orleans;
+using SignalR.Orleans.Core;
 
 namespace SignalR.Orleans.Clients
 {
-    public interface IClientGrain : IGrainWithStringKey
+    public interface IClientGrain : IHubMessageInvoker, IGrainWithStringKey
     {
-        Task SendMessage(object message);
         Task OnConnect(Guid serverId);
         Task OnDisconnect();
     }

--- a/src/SignalR.Orleans/Clients/IClientGrain.cs
+++ b/src/SignalR.Orleans/Clients/IClientGrain.cs
@@ -7,7 +7,7 @@ namespace SignalR.Orleans.Clients
     public interface IClientGrain : IGrainWithStringKey
     {
         Task SendMessage(object message);
-        Task OnConnect(Guid serverId, string hubName, string connectionId);
+        Task OnConnect(Guid serverId);
         Task OnDisconnect();
     }
 }

--- a/src/SignalR.Orleans/Core/ConnectionGrain.cs
+++ b/src/SignalR.Orleans/Core/ConnectionGrain.cs
@@ -24,7 +24,7 @@ namespace SignalR.Orleans.Core
                 var subscriptions = await clientDisconnectStream.GetAllSubscriptionHandles();
                 foreach (var subscription in subscriptions)
                 {
-                    subscriptionTasks.Add(subscription.ResumeAsync(async (connectionId, token) => await Remove(connectionId)));
+                    subscriptionTasks.Add(subscription.ResumeAsync(async (connectionId, _) => await Remove(connectionId)));
                 }
             }
             await Task.WhenAll(subscriptionTasks);
@@ -36,7 +36,7 @@ namespace SignalR.Orleans.Core
                 return;
 
             var clientDisconnectStream = _streamProvider.GetStream<string>(Constants.CLIENT_DISCONNECT_STREAM_ID, connectionId);
-            var subscription = await clientDisconnectStream.SubscribeAsync(async (connId, token) => await Remove(connId));
+            var subscription = await clientDisconnectStream.SubscribeAsync(async (connId, _) => await Remove(connId));
             State.Connections.Add(connectionId, subscription);
             await WriteStateAsync();
         }

--- a/src/SignalR.Orleans/Core/ConnectionGrain.cs
+++ b/src/SignalR.Orleans/Core/ConnectionGrain.cs
@@ -25,6 +25,7 @@ namespace SignalR.Orleans.Core
             await Task.WhenAll(subscriptionTasks);
         }
 
+        // todo: remove hubname (since its already in pk)
         public virtual async Task Add(string hubName, string connectionId)
         {
             if (!this.State.Connections.ContainsKey(connectionId))
@@ -41,9 +42,10 @@ namespace SignalR.Orleans.Core
 
         public virtual async Task Remove(string connectionId)
         {
-            if (State.Connections.ContainsKey(connectionId))
+            // todo: ensure deleted 
+            if (State.Connections.TryGetValue(connectionId, out var stream))
             {
-                await this.State.Connections[connectionId].UnsubscribeAsync();
+                await stream.UnsubscribeAsync();
                 this.State.Connections.Remove(connectionId);
             }
             if (this.State.Connections.Count == 0)
@@ -75,6 +77,7 @@ namespace SignalR.Orleans.Core
         }
     }
 
+    // todo: debugger display
     internal abstract class ConnectionState
     {
         public Dictionary<string, StreamSubscriptionHandle<string>> Connections { get; set; } = new Dictionary<string, StreamSubscriptionHandle<string>>();

--- a/src/SignalR.Orleans/Core/ConnectionGrainKey.cs
+++ b/src/SignalR.Orleans/Core/ConnectionGrainKey.cs
@@ -1,0 +1,28 @@
+﻿using System.Diagnostics;
+
+namespace SignalR.Orleans.Core
+{
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    internal struct ConnectionGrainKey
+    {
+        private string DebuggerDisplay => $"HubName: '{HubName}', Id: '{Id}'";
+        public string HubName { get; set; }
+        public string Id { get; set; }
+
+        public ConnectionGrainKey(string primaryKey) : this()
+        {
+            Parse(primaryKey);
+        }
+
+        public void Parse(string primaryKey)
+        {
+            var pkArray = primaryKey.Split(':');
+
+            HubName = pkArray[0];
+            Id = pkArray[1];
+        }
+
+        public static string Build(string hubName, string key)
+            => $"{hubName}:{key}";
+    }
+}

--- a/src/SignalR.Orleans/Core/GrainExtensions.cs
+++ b/src/SignalR.Orleans/Core/GrainExtensions.cs
@@ -26,12 +26,12 @@ namespace Orleans
         }
 
         internal static IClientGrain GetClientGrain(this IGrainFactory factory, string hubName, string connectionId)
-            => factory.GetGrain<IClientGrain>(Utils.BuildGrainId(hubName, connectionId));
+            => factory.GetGrain<IClientGrain>(ConnectionGrainKey.Build(hubName, connectionId));
 
         internal static IGroupGrain GetGroupGrain(this IGrainFactory factory, string hubName, string groupName)
-            => factory.GetGrain<IGroupGrain>(Utils.BuildGrainId(hubName, groupName));
+            => factory.GetGrain<IGroupGrain>(ConnectionGrainKey.Build(hubName, groupName));
 
         internal static IUserGrain GetUserGrain(this IGrainFactory factory, string hubName, string userId)
-            => factory.GetGrain<IUserGrain>(Utils.BuildGrainId(hubName, userId));
+            => factory.GetGrain<IUserGrain>(ConnectionGrainKey.Build(hubName, userId));
     }
 }

--- a/src/SignalR.Orleans/Core/GrainExtensions.cs
+++ b/src/SignalR.Orleans/Core/GrainExtensions.cs
@@ -10,6 +10,7 @@ namespace Orleans
 {
     public static class GrainSignalRExtensions
     {
+        // todo: rename to Send or SendSignalR? -- Add interface for ClientGrain and ConnectionGrain so this is shared
         public static async Task SendSignalRMessage(this IConnectionGrain grain, string methodName, params object[] message)
         {
             var invocationMessage = new InvocationMessage(methodName, message);

--- a/src/SignalR.Orleans/Core/GrainExtensions.cs
+++ b/src/SignalR.Orleans/Core/GrainExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR.Protocol;
 using SignalR.Orleans.Clients;
 using SignalR.Orleans.Core;
@@ -10,11 +11,23 @@ namespace Orleans
 {
     public static class GrainSignalRExtensions
     {
-        // todo: rename to Send or SendSignalR? -- Add interface for ClientGrain and ConnectionGrain so this is shared
+        [Obsolete("Use Send instead", false)]
         public static async Task SendSignalRMessage(this IConnectionGrain grain, string methodName, params object[] message)
         {
             var invocationMessage = new InvocationMessage(methodName, message);
-            await grain.SendMessage(invocationMessage);
+            await grain.Send(invocationMessage);
+        }
+
+        /// <summary>
+        /// Invokes a method on the hub.
+        /// </summary>
+        /// <param name="grain"></param>
+        /// <param name="methodName">Target method name to invoke.</param>
+        /// <param name="args">Arguments to pass to the target method.</param>
+        public static Task Send(this IHubMessageInvoker grain, string methodName, params object[] args)
+        {
+            var invocationMessage = new InvocationMessage(methodName, args);
+            return grain.Send(invocationMessage);
         }
     }
 

--- a/src/SignalR.Orleans/Core/HubContext.cs
+++ b/src/SignalR.Orleans/Core/HubContext.cs
@@ -22,6 +22,5 @@ namespace SignalR.Orleans.Core
         public IClientGrain Client(string connectionId) => _grainFactory.GetClientGrain(_hubName, connectionId);
         public IGroupGrain Group(string groupName) => _grainFactory.GetGroupGrain(_hubName, groupName);
         public IUserGrain User(string userId) => _grainFactory.GetUserGrain(_hubName, userId);
-
     }
 }

--- a/src/SignalR.Orleans/Core/IConnectionGrain.cs
+++ b/src/SignalR.Orleans/Core/IConnectionGrain.cs
@@ -1,11 +1,11 @@
-﻿using Orleans;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
+using Orleans;
 
 namespace SignalR.Orleans.Core
 {
     public interface IConnectionGrain : IGrainWithStringKey
     {
-        Task Add(string hubName, string connectionId);
+        Task Add(string connectionId);
         Task Remove(string connectionId);
         Task SendMessage(object message);
         Task<int> Count();

--- a/src/SignalR.Orleans/Core/IConnectionGrain.cs
+++ b/src/SignalR.Orleans/Core/IConnectionGrain.cs
@@ -1,13 +1,37 @@
-﻿using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using Orleans;
 
 namespace SignalR.Orleans.Core
 {
-    public interface IConnectionGrain : IGrainWithStringKey
+    /// <summary>
+    /// Grain interface Grouped of connections, such as user or custom group.
+    /// </summary>
+    public interface IConnectionGrain : IHubMessageInvoker, IGrainWithStringKey
     {
+        /// <summary>
+        /// Add connection id to the group.
+        /// </summary>
+        /// <param name="connectionId">Connection id to add.</param>
         Task Add(string connectionId);
+
+        /// <summary>
+        /// Remove the connection id to the group.
+        /// </summary>
+        /// <param name="connectionId">Connection id to remove.</param>
         Task Remove(string connectionId);
-        Task SendMessage(object message);
+
+        /// <summary>
+        /// Gets the connection count in the group.
+        /// </summary>
         Task<int> Count();
+
+        /// <summary>
+        /// Invokes a method on the hub except the specified connection ids.
+        /// </summary>
+        /// <param name="methodName">Target method name to invoke.</param>
+        /// <param name="args">Arguments to pass to the target method.</param>
+        /// <param name="excludedConnectionIds">Connection ids to exclude.</param>
+        Task SendExcept(string methodName, object[] args, IReadOnlyList<string> excludedConnectionIds);
     }
 }

--- a/src/SignalR.Orleans/Core/IHubMessageInvoker.cs
+++ b/src/SignalR.Orleans/Core/IHubMessageInvoker.cs
@@ -1,0 +1,14 @@
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.SignalR.Protocol;
+
+namespace SignalR.Orleans.Core
+{
+    public interface IHubMessageInvoker
+    {
+        /// <summary>
+        /// Invokes a method on the hub.
+        /// </summary>
+        /// <param name="message">Message to invoke.</param>
+        Task Send(InvocationMessage message);
+    }
+}

--- a/src/SignalR.Orleans/Core/Utils.cs
+++ b/src/SignalR.Orleans/Core/Utils.cs
@@ -2,9 +2,9 @@
 {
     internal static class Utils
     {
-        internal static string BuildGrainId(string hubName, string key) => $"{hubName}:{key}".ToLower();
+        internal static string BuildGrainId(string hubName, string key) => $"{hubName}:{key}";
 
-	    internal static string BuildStreamHubName(string hubName) => $"registered-hub::{hubName}".ToLower();
+        internal static string BuildStreamHubName(string hubName) => $"registered-hub::{hubName}".ToLower();
 
-	}
+    }
 }

--- a/src/SignalR.Orleans/Core/Utils.cs
+++ b/src/SignalR.Orleans/Core/Utils.cs
@@ -2,9 +2,6 @@
 {
     internal static class Utils
     {
-        internal static string BuildGrainId(string hubName, string key) => $"{hubName}:{key}";
-
         internal static string BuildStreamHubName(string hubName) => $"registered-hub::{hubName}".ToLower();
-
     }
 }

--- a/src/SignalR.Orleans/Groups/GroupGrain.cs
+++ b/src/SignalR.Orleans/Groups/GroupGrain.cs
@@ -18,7 +18,7 @@ namespace SignalR.Orleans.Groups
             {
                 if (excludedIds.Contains(connection.Key)) continue;
 
-                var client = GrainFactory.GetClientGrain(State.HubName, connection.Key);
+                var client = GrainFactory.GetClientGrain(KeyData.HubName, connection.Key);
                 tasks.Add(client.SendMessage(message));
             }
 

--- a/src/SignalR.Orleans/Groups/GroupGrain.cs
+++ b/src/SignalR.Orleans/Groups/GroupGrain.cs
@@ -1,7 +1,3 @@
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using Orleans;
 using Orleans.Providers;
 using SignalR.Orleans.Core;
 
@@ -10,20 +6,6 @@ namespace SignalR.Orleans.Groups
     [StorageProvider(ProviderName = Constants.STORAGE_PROVIDER)]
     internal class GroupGrain : ConnectionGrain<GroupState>, IGroupGrain
     {
-        // todo: remove from object message and pass args
-        public Task SendMessageExcept(object message, IReadOnlyList<string> excludedIds)
-        {
-            var tasks = new List<Task>();
-            foreach (var connection in State.Connections)
-            {
-                if (excludedIds.Contains(connection.Key)) continue;
-
-                var client = GrainFactory.GetClientGrain(KeyData.HubName, connection.Key);
-                tasks.Add(client.SendMessage(message));
-            }
-
-            return Task.WhenAll(tasks);
-        }
     }
 
     internal class GroupState : ConnectionState

--- a/src/SignalR.Orleans/Groups/GroupGrain.cs
+++ b/src/SignalR.Orleans/Groups/GroupGrain.cs
@@ -10,10 +10,11 @@ namespace SignalR.Orleans.Groups
     [StorageProvider(ProviderName = Constants.STORAGE_PROVIDER)]
     internal class GroupGrain : ConnectionGrain<GroupState>, IGroupGrain
     {
+        // todo: remove from object message and pass args
         public Task SendMessageExcept(object message, IReadOnlyList<string> excludedIds)
         {
             var tasks = new List<Task>();
-            foreach (var connection in this.State.Connections)
+            foreach (var connection in State.Connections)
             {
                 if (excludedIds.Contains(connection.Key)) continue;
 

--- a/src/SignalR.Orleans/Groups/IGroupGrain.cs
+++ b/src/SignalR.Orleans/Groups/IGroupGrain.cs
@@ -1,11 +1,8 @@
-using System.Collections.Generic;
-using System.Threading.Tasks;
 using SignalR.Orleans.Core;
 
 namespace SignalR.Orleans.Groups
 {
     public interface IGroupGrain : IConnectionGrain
     {
-        Task SendMessageExcept(object message, IReadOnlyList<string> excludedIds);
     }
 }

--- a/src/SignalR.Orleans/IClusterClientProvider.cs
+++ b/src/SignalR.Orleans/IClusterClientProvider.cs
@@ -13,9 +13,9 @@ namespace SignalR.Orleans
 
         public DefaultClusterClientProvider(IClusterClient clusterClient)
         {
-            this._clusterClient = clusterClient;
+            _clusterClient = clusterClient;
         }
 
-        public IClusterClient GetClient() => this._clusterClient;
+        public IClusterClient GetClient() => _clusterClient;
     }
 }

--- a/src/SignalR.Orleans/OrleansHubLifetimeManager.cs
+++ b/src/SignalR.Orleans/OrleansHubLifetimeManager.cs
@@ -91,7 +91,7 @@ namespace SignalR.Orleans
                 if (connection.User.Identity.IsAuthenticated)
                 {
                     var user = _clusterClientProvider.GetClient().GetUserGrain(_hubName, connection.UserIdentifier);
-                    await user.Add(_hubName, connection.ConnectionId);
+                    await user.Add(connection.ConnectionId);
                 }
 
                 var client = _clusterClientProvider.GetClient().GetClientGrain(_hubName, connection.ConnectionId);
@@ -203,7 +203,7 @@ namespace SignalR.Orleans
             CancellationToken cancellationToken = new CancellationToken())
         {
             var group = _clusterClientProvider.GetClient().GetGroupGrain(_hubName, groupName);
-            return group.Add(_hubName, connectionId);
+            return group.Add(connectionId);
         }
 
         public override Task RemoveFromGroupAsync(string connectionId, string groupName,

--- a/src/SignalR.Orleans/OrleansHubLifetimeManager.cs
+++ b/src/SignalR.Orleans/OrleansHubLifetimeManager.cs
@@ -44,8 +44,8 @@ namespace SignalR.Orleans
 
             var subscribeTasks = new List<Task>
             {
-                _allStream.SubscribeAsync((msg, token) => ProcessAllMessage(msg)),
-                _serverStream.SubscribeAsync((msg, token) => ProcessServerMessage(msg))
+                _allStream.SubscribeAsync((msg, _) => ProcessAllMessage(msg)),
+                _serverStream.SubscribeAsync((msg, _) => ProcessServerMessage(msg))
             };
 
             await Task.WhenAll(subscribeTasks);
@@ -56,7 +56,7 @@ namespace SignalR.Orleans
         private Task ProcessAllMessage(AllMessage message)
         {
             var allTasks = new List<Task>(_connections.Count);
-            var payload = (InvocationMessage)message.Payload;
+            var payload = message.Payload;
 
             foreach (var connection in _connections)
             {
@@ -244,6 +244,6 @@ namespace SignalR.Orleans
     public class AllMessage
     {
         public IReadOnlyList<string> ExcludedIds { get; set; }
-        public object Payload { get; set; }
+        public InvocationMessage Payload { get; set; }
     }
 }

--- a/src/SignalR.Orleans/OrleansHubLifetimeManager.cs
+++ b/src/SignalR.Orleans/OrleansHubLifetimeManager.cs
@@ -161,7 +161,7 @@ namespace SignalR.Orleans
             if (string.IsNullOrWhiteSpace(methodName)) throw new ArgumentNullException(nameof(methodName));
 
             var group = _clusterClientProvider.GetClient().GetGroupGrain(_hubName, groupName);
-            return group.SendSignalRMessage(methodName, args);
+            return group.Send(methodName, args);
         }
 
         public override Task SendGroupsAsync(IReadOnlyList<string> groupNames, string methodName, object[] args,
@@ -178,8 +178,7 @@ namespace SignalR.Orleans
             if (string.IsNullOrWhiteSpace(methodName)) throw new ArgumentNullException(nameof(methodName));
 
             var group = _clusterClientProvider.GetClient().GetGroupGrain(_hubName, groupName);
-            var invocationMessage = new InvocationMessage(methodName, args);
-            return group.SendMessageExcept(invocationMessage, excludedConnectionIds);
+            return group.SendExcept(methodName, args, excludedConnectionIds);
         }
 
         public override Task SendUserAsync(string userId, string methodName, object[] args,
@@ -189,7 +188,7 @@ namespace SignalR.Orleans
             if (string.IsNullOrWhiteSpace(methodName)) throw new ArgumentNullException(nameof(methodName));
 
             var user = _clusterClientProvider.GetClient().GetUserGrain(_hubName, userId);
-            return user.SendSignalRMessage(methodName, args);
+            return user.Send(methodName, args);
         }
 
         public override Task SendUsersAsync(IReadOnlyList<string> userIds, string methodName, object[] args,
@@ -218,10 +217,10 @@ namespace SignalR.Orleans
             return connection.WriteAsync(hubMessage).AsTask();
         }
 
-        private Task SendExternal(string connectionId, object hubMessage)
+        private Task SendExternal(string connectionId, InvocationMessage hubMessage)
         {
             var client = _clusterClientProvider.GetClient().GetClientGrain(_hubName, connectionId);
-            return client.SendMessage(hubMessage);
+            return client.Send(hubMessage);
         }
 
         public void Dispose()

--- a/src/SignalR.Orleans/OrleansHubLifetimeManager.cs
+++ b/src/SignalR.Orleans/OrleansHubLifetimeManager.cs
@@ -74,7 +74,7 @@ namespace SignalR.Orleans
             var connection = _connections[message.ConnectionId];
             if (connection == null) return Task.CompletedTask; // TODO: Log
 
-            return SendLocal(connection, (InvocationMessage)message.Payload);
+            return SendLocal(connection, message.Payload);
         }
 
         public override async Task OnConnectedAsync(HubConnectionContext connection)
@@ -112,8 +112,7 @@ namespace SignalR.Orleans
 
             if (connection.User.Identity.IsAuthenticated)
             {
-                //TODO: replace `connection.User.Identity.Name` with `connection.UserIdentifier` when next signalr will be published.
-                var user = _clusterClientProvider.GetClient().GetUserGrain(_hubName, connection.User.Identity.Name);
+                var user = _clusterClientProvider.GetClient().GetUserGrain(_hubName, connection.UserIdentifier);
                 await user.Remove(connection.ConnectionId);
             }
 

--- a/src/SignalR.Orleans/OrleansHubLifetimeManager.cs
+++ b/src/SignalR.Orleans/OrleansHubLifetimeManager.cs
@@ -26,7 +26,8 @@ namespace SignalR.Orleans
 
         public OrleansHubLifetimeManager(
             ILogger<OrleansHubLifetimeManager<THub>> logger,
-            IClusterClientProvider clusterClientProvider)
+            IClusterClientProvider clusterClientProvider
+        )
         {
             _serverId = Guid.NewGuid();
             this._logger = logger;
@@ -36,7 +37,7 @@ namespace SignalR.Orleans
         private async Task SetupStreams()
         {
             _logger.LogInformation("Initializing: Orleans HubLifetimeManager {hubName} (serverId: {serverId})...", _hubName, _serverId);
-            
+
             this._streamProvider = this._clusterClientProvider.GetClient().GetStreamProvider(Constants.STREAM_PROVIDER);
             this._serverStream = this._streamProvider.GetStream<ClientMessage>(_serverId, Constants.SERVERS_STREAM);
             this._allStream = this._streamProvider.GetStream<AllMessage>(Constants.ALL_STREAM_ID, Utils.BuildStreamHubName(this._hubName));

--- a/test/SignalR.Orleans.Tests/OrleansFixture.cs
+++ b/test/SignalR.Orleans.Tests/OrleansFixture.cs
@@ -20,7 +20,7 @@ namespace SignalR.Orleans.Tests
                 .UseSignalR()
                 .Build();
             silo.StartAsync().Wait();
-            this.Silo = silo;
+            Silo = silo;
 
             var client = new ClientBuilder()
                 .UseLocalhostClustering()
@@ -29,7 +29,7 @@ namespace SignalR.Orleans.Tests
                 .Build();
 
             client.Connect().Wait();
-            this.ClientProvider = new DefaultClusterClientProvider(client);
+            ClientProvider = new DefaultClusterClientProvider(client);
         }
 
         public void Dispose()

--- a/test/SignalR.Orleans.Tests/OrleansHubLifetimeManagerTests.cs
+++ b/test/SignalR.Orleans.Tests/OrleansHubLifetimeManagerTests.cs
@@ -18,7 +18,7 @@ namespace SignalR.Orleans.Tests
 
         public OrleansHubLifetimeManagerTests(OrleansFixture fixture)
         {
-            this._fixture = fixture;
+            _fixture = fixture;
         }
 
         [Fact]
@@ -27,7 +27,7 @@ namespace SignalR.Orleans.Tests
             using (var client1 = new TestClient())
             using (var client2 = new TestClient())
             {
-                var manager = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), this._fixture.ClientProvider);
+                var manager = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), _fixture.ClientProvider);
 
                 var connection1 = HubConnectionContextUtils.Create(client1.Connection);
                 var connection2 = HubConnectionContextUtils.Create(client2.Connection);
@@ -48,7 +48,7 @@ namespace SignalR.Orleans.Tests
             using (var client1 = new TestClient())
             using (var client2 = new TestClient())
             {
-                var manager = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), this._fixture.ClientProvider);
+                var manager = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), _fixture.ClientProvider);
 
                 var connection1 = HubConnectionContextUtils.Create(client1.Connection);
                 var connection2 = HubConnectionContextUtils.Create(client2.Connection);
@@ -72,7 +72,7 @@ namespace SignalR.Orleans.Tests
             using (var client1 = new TestClient())
             using (var client2 = new TestClient())
             {
-                var manager = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), this._fixture.ClientProvider);
+                var manager = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), _fixture.ClientProvider);
                 var connection1 = HubConnectionContextUtils.Create(client1.Connection);
                 var connection2 = HubConnectionContextUtils.Create(client2.Connection);
 
@@ -95,7 +95,7 @@ namespace SignalR.Orleans.Tests
             using (var client1 = new TestClient())
             using (var client2 = new TestClient())
             {
-                var manager = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), this._fixture.ClientProvider);
+                var manager = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), _fixture.ClientProvider);
                 var connection1 = HubConnectionContextUtils.Create(client1.Connection);
                 var connection2 = HubConnectionContextUtils.Create(client2.Connection);
 
@@ -119,7 +119,7 @@ namespace SignalR.Orleans.Tests
             using (var client1 = new TestClient())
             using (var client2 = new TestClient())
             {
-                var manager = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), this._fixture.ClientProvider);
+                var manager = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), _fixture.ClientProvider);
                 var connection1 = HubConnectionContextUtils.Create(client1.Connection);
                 var connection2 = HubConnectionContextUtils.Create(client2.Connection);
 
@@ -141,7 +141,7 @@ namespace SignalR.Orleans.Tests
         {
             using (var client = new TestClient())
             {
-                var manager = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), this._fixture.ClientProvider);
+                var manager = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), _fixture.ClientProvider);
                 var connection = HubConnectionContextUtils.Create(client.Connection);
 
                 await manager.OnConnectedAsync(connection);
@@ -158,7 +158,7 @@ namespace SignalR.Orleans.Tests
             using (var client1 = new TestClient())
             using (var client2 = new TestClient())
             {
-                var manager = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), this._fixture.ClientProvider);
+                var manager = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), _fixture.ClientProvider);
                 var connection1 = HubConnectionContextUtils.Create(client1.Connection);
                 var connection2 = HubConnectionContextUtils.Create(client2.Connection);
 
@@ -176,24 +176,24 @@ namespace SignalR.Orleans.Tests
         public async Task InvokeConnectionAsync_OnNonExistentConnection_DoesNotThrow()
         {
             var invalidConnection = "NotARealConnectionId";
-            var grain = this._fixture.ClientProvider.GetClient().GetClientGrain("MyHub", invalidConnection);
-            await grain.OnConnect(Guid.NewGuid(), "MyHub", invalidConnection);
-            var manager = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), this._fixture.ClientProvider);
+            var grain = _fixture.ClientProvider.GetClient().GetClientGrain("MyHub", invalidConnection);
+            await grain.OnConnect(Guid.NewGuid());
+            var manager = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), _fixture.ClientProvider);
             await manager.SendConnectionAsync(invalidConnection, "Hello", new object[] { "World" });
         }
 
         [Fact]
         public async Task InvokeConnectionAsync_OnNonExistentConnection_WithoutCalling_OnConnect_ThrowsException()
         {
-            var manager = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), this._fixture.ClientProvider);
+            var manager = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), _fixture.ClientProvider);
             await Assert.ThrowsAsync<InvalidOperationException>(() => manager.SendConnectionAsync("NotARealConnectionIdV2", "Hello", new object[] { "World" }));
         }
 
         [Fact]
         public async Task InvokeAllAsync_WithMultipleServers_WritesToAllConnections_Output()
         {
-            var manager1 = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), this._fixture.ClientProvider);
-            var manager2 = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), this._fixture.ClientProvider);
+            var manager1 = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), _fixture.ClientProvider);
+            var manager2 = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), _fixture.ClientProvider);
 
             using (var client1 = new TestClient())
             using (var client2 = new TestClient())
@@ -214,8 +214,8 @@ namespace SignalR.Orleans.Tests
         [Fact]
         public async Task InvokeAllAsync_WithMultipleServers_DoesNotWrite_ToDisconnectedConnections_Output()
         {
-            var manager1 = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), this._fixture.ClientProvider);
-            var manager2 = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), this._fixture.ClientProvider);
+            var manager1 = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), _fixture.ClientProvider);
+            var manager2 = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), _fixture.ClientProvider);
 
             using (var client1 = new TestClient())
             using (var client2 = new TestClient())
@@ -239,8 +239,8 @@ namespace SignalR.Orleans.Tests
         [Fact]
         public async Task InvokeConnectionAsync_OnServer_WithoutConnection_WritesOutputTo_Connection()
         {
-            var manager1 = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), this._fixture.ClientProvider);
-            var manager2 = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), this._fixture.ClientProvider);
+            var manager1 = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), _fixture.ClientProvider);
+            var manager2 = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), _fixture.ClientProvider);
 
             using (var client = new TestClient())
             {
@@ -257,8 +257,8 @@ namespace SignalR.Orleans.Tests
         [Fact]
         public async Task InvokeGroupAsync_OnServer_WithoutConnection_WritesOutputTo_GroupConnection()
         {
-            var manager1 = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), this._fixture.ClientProvider);
-            var manager2 = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), this._fixture.ClientProvider);
+            var manager1 = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), _fixture.ClientProvider);
+            var manager2 = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), _fixture.ClientProvider);
 
             using (var client = new TestClient())
             {
@@ -277,7 +277,7 @@ namespace SignalR.Orleans.Tests
         [Fact]
         public async Task DisconnectConnection_RemovesConnection_FromGroup()
         {
-            var manager = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), this._fixture.ClientProvider);
+            var manager = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), _fixture.ClientProvider);
 
             using (var client = new TestClient())
             {
@@ -289,7 +289,7 @@ namespace SignalR.Orleans.Tests
 
                 await manager.OnDisconnectedAsync(connection);
 
-                var grain = this._fixture.ClientProvider.GetClient().GetGroupGrain("MyHub", "dre");
+                var grain = _fixture.ClientProvider.GetClient().GetGroupGrain("MyHub", "dre");
                 var result = await grain.Count();
                 Assert.Equal(0, result);
             }
@@ -298,7 +298,7 @@ namespace SignalR.Orleans.Tests
         [Fact]
         public async Task RemoveGroup_FromLocalConnection_NotInGroup_DoesNothing()
         {
-            var manager = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), this._fixture.ClientProvider);
+            var manager = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), _fixture.ClientProvider);
 
             using (var client = new TestClient())
             {
@@ -313,8 +313,8 @@ namespace SignalR.Orleans.Tests
         [Fact]
         public async Task RemoveGroup_FromConnection_OnDifferentServer_NotInGroup_DoesNothing()
         {
-            var manager1 = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), this._fixture.ClientProvider);
-            var manager2 = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), this._fixture.ClientProvider);
+            var manager1 = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), _fixture.ClientProvider);
+            var manager2 = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), _fixture.ClientProvider);
 
             using (var client = new TestClient())
             {
@@ -329,8 +329,8 @@ namespace SignalR.Orleans.Tests
         [Fact]
         public async Task AddGroupAsync_ForConnection_OnDifferentServer_Works()
         {
-            var manager1 = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), this._fixture.ClientProvider);
-            var manager2 = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), this._fixture.ClientProvider);
+            var manager1 = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), _fixture.ClientProvider);
+            var manager2 = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), _fixture.ClientProvider);
 
             using (var client = new TestClient())
             {
@@ -349,7 +349,7 @@ namespace SignalR.Orleans.Tests
         [Fact]
         public async Task AddGroupAsync_ForLocalConnection_AlreadyInGroup_SkipsDuplicate()
         {
-            var manager = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), this._fixture.ClientProvider);
+            var manager = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), _fixture.ClientProvider);
 
             using (var client = new TestClient())
             {
@@ -360,7 +360,7 @@ namespace SignalR.Orleans.Tests
                 await manager.AddToGroupAsync(connection.ConnectionId, "dmx");
                 await manager.AddToGroupAsync(connection.ConnectionId, "dmx");
 
-                var grain = this._fixture.ClientProvider.GetClient().GetGroupGrain("MyHub", "dmx");
+                var grain = _fixture.ClientProvider.GetClient().GetGroupGrain("MyHub", "dmx");
                 var result = await grain.Count();
                 Assert.Equal(1, result);
             }
@@ -369,8 +369,8 @@ namespace SignalR.Orleans.Tests
         [Fact]
         public async Task AddGroupAsync_ForConnection_OnDifferentServer_AlreadyInGroup_SkipsDuplicate()
         {
-            var manager1 = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), this._fixture.ClientProvider);
-            var manager2 = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), this._fixture.ClientProvider);
+            var manager1 = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), _fixture.ClientProvider);
+            var manager2 = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), _fixture.ClientProvider);
 
             using (var client = new TestClient())
             {
@@ -391,8 +391,8 @@ namespace SignalR.Orleans.Tests
         [Fact]
         public async Task RemoveGroupAsync_ForConnection_OnDifferentServer_Works()
         {
-            var manager1 = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), this._fixture.ClientProvider);
-            var manager2 = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), this._fixture.ClientProvider);
+            var manager1 = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), _fixture.ClientProvider);
+            var manager2 = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), _fixture.ClientProvider);
 
             using (var client = new TestClient())
             {
@@ -417,8 +417,8 @@ namespace SignalR.Orleans.Tests
         [Fact]
         public async Task InvokeConnectionAsync_ForLocalConnection_DoesNotPublish()
         {
-            var manager1 = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), this._fixture.ClientProvider);
-            var manager2 = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), this._fixture.ClientProvider);
+            var manager1 = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), _fixture.ClientProvider);
+            var manager2 = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), _fixture.ClientProvider);
 
             using (var client = new TestClient())
             {
@@ -438,9 +438,9 @@ namespace SignalR.Orleans.Tests
         [Fact]
         public async Task InvokeAllAsync_ForSpecificHub_WithMultipleServers_WritesTo_AllConnections_Output()
         {
-            var manager1 = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), this._fixture.ClientProvider);
-            var manager2 = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), this._fixture.ClientProvider);
-            var manager3 = new OrleansHubLifetimeManager<DifferentHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<DifferentHub>>(), this._fixture.ClientProvider);
+            var manager1 = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), _fixture.ClientProvider);
+            var manager2 = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), _fixture.ClientProvider);
+            var manager3 = new OrleansHubLifetimeManager<DifferentHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<DifferentHub>>(), _fixture.ClientProvider);
 
             using (var client1 = new TestClient())
             using (var client2 = new TestClient())

--- a/test/SignalR.Orleans.Tests/OrleansHubLifetimeManagerTests.cs
+++ b/test/SignalR.Orleans.Tests/OrleansHubLifetimeManagerTests.cs
@@ -210,13 +210,6 @@ namespace SignalR.Orleans.Tests
         }
 
         [Fact]
-        public async Task InvokeConnectionAsync_OnNonExistentConnection_WithoutCalling_OnConnect_ThrowsException()
-        {
-            var manager = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), _fixture.ClientProvider);
-            await Assert.ThrowsAsync<InvalidOperationException>(() => manager.SendConnectionAsync("NotARealConnectionIdV2", "Hello", new object[] { "World" }));
-        }
-
-        [Fact]
         public async Task InvokeAllAsync_WithMultipleServers_WritesToAllConnections_Output()
         {
             var manager1 = new OrleansHubLifetimeManager<MyHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<MyHub>>(), _fixture.ClientProvider);

--- a/test/SignalR.Orleans.Tests/OrleansHubLifetimeManagerTests.cs
+++ b/test/SignalR.Orleans.Tests/OrleansHubLifetimeManagerTests.cs
@@ -295,6 +295,8 @@ namespace SignalR.Orleans.Tests
             }
         }
 
+        // todo: add test - multi conn, one "not connected" others connected - ensure 2 gets delivered and 1 doesnt (and not failing the rest)
+
         [Fact]
         public async Task RemoveGroup_FromLocalConnection_NotInGroup_DoesNothing()
         {


### PR DESCRIPTION
Several refactoring and improvements.

Even though there seems to be a lot of breaking changes, the consumers should have minimal to none breaking. the most one that will affect them is the renaming `SendSignalRMessage` to `Send` however its deprecated so shouldn't be an issue.

### Refactoring/Improvements
- Align `Send` message method naming `SendSignalRMessage`, and `SendMessage` to just `Send` to be more inline also with SignalR
- `SendMessage`, `SendMessageExcept` message has now been typed instead of `object` to `InvocationMessage`
- `SendExcept` has now been moved to `ConnectionGrain` instead of `GroupGrain`, so now its more reachable (if desired)
- Cleanup grain method args `hubName` and `connectionId` and now using grain primary key instead, which might also be less error-prone as well + simplified API and code.
- Created `IHubMessageInvoker` which both Client/Connection Grains use and `Send` extension method is now available for `IClientGrain` as well

### Fixes
- Fix an issue when sending a message to a group/user, and a client is not connected (1 or so) it will fail to send to the rest
- Fix todo in `OrleansHubLifetimeManagement` to use `connection.UserIdentifier` instead of `connection.User.Identity.Name` directly, so it is now configurable, and also will remove correctly from the grain (as Connect was already using it)

### Code Style
- Remove redundant `this.` (as specified in `.editorconfig`), since build was failing for me due to that (in vs2019 + using editorconfig ext) 

### BREAKING CHANGES
- **group:** `SendMessageExcept` renamed to `SendExcept`
- Due to primarykey changes (removed `.ToLower`) and removing some State data (as now reading from key) it is suggested to clear any persisted state for both pubsub and storage providers

### Deprecated
- `SendSignalRMessage` has been renamed to `Send`

Sorry for the big PR, however since I had some breaking changes thought might as well combine them into one