### PR TITLE
feat(hub): hub naming now is invariant and will always use interface naming

### DIFF
--- a/src/SignalR.Orleans/OrleansHubLifetimeManager.cs
+++ b/src/SignalR.Orleans/OrleansHubLifetimeManager.cs
@@ -22,13 +22,17 @@ namespace SignalR.Orleans
         private IStreamProvider _streamProvider;
         private IAsyncStream<ClientMessage> _serverStream;
         private IAsyncStream<AllMessage> _allStream;
-        private readonly string _hubName = typeof(THub).Name;
+        private readonly string _hubName;
 
         public OrleansHubLifetimeManager(
             ILogger<OrleansHubLifetimeManager<THub>> logger,
             IClusterClientProvider clusterClientProvider
         )
         {
+            var hubType = typeof(THub).BaseType.GenericTypeArguments[0];
+            _hubName = hubType.IsInterface && hubType.Name.StartsWith("I")
+                ? hubType.Name.Substring(1)
+                : hubType.Name;
             _serverId = Guid.NewGuid();
             _logger = logger;
             _clusterClientProvider = clusterClientProvider;

--- a/src/SignalR.Orleans/OrleansHubLifetimeManager.cs
+++ b/src/SignalR.Orleans/OrleansHubLifetimeManager.cs
@@ -29,7 +29,7 @@ namespace SignalR.Orleans
             IClusterClientProvider clusterClientProvider
         )
         {
-            var hubType = typeof(THub).BaseType.GenericTypeArguments[0];
+            var hubType = typeof(THub).BaseType.GenericTypeArguments.FirstOrDefault() ?? typeof(THub);
             _hubName = hubType.IsInterface && hubType.Name.StartsWith("I")
                 ? hubType.Name.Substring(1)
                 : hubType.Name;

--- a/test/SignalR.Orleans.Tests/Models/Hub.cs
+++ b/test/SignalR.Orleans.Tests/Models/Hub.cs
@@ -11,4 +11,25 @@ namespace SignalR.Orleans.Tests.Models
     {
 
     }
+
+    // matching interface naming
+    public class DaHub : Hub<IDaHub>
+    {
+    }
+
+    public interface IDaHub { }
+
+    // non matching interface and class
+    public class DaHubx : Hub<IDaHub>
+    {
+    }
+
+    // using base
+    public class DaHubUsingBase : DaGenericHubBase<IDaHub>
+    {
+    }
+
+    public class DaGenericHubBase<THub> : Hub<THub> where THub : class
+    {
+    }
 }

--- a/test/SignalR.Orleans.Tests/OrleansHubLifetimeManagerTests.cs
+++ b/test/SignalR.Orleans.Tests/OrleansHubLifetimeManagerTests.cs
@@ -43,6 +43,57 @@ namespace SignalR.Orleans.Tests
         }
 
         [Fact]
+        public async Task Hub_InterfaceMatchingNaming_Output()
+        {
+            using (var client1 = new TestClient())
+            {
+                var manager = new OrleansHubLifetimeManager<DaHub>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<DaHub>>(), _fixture.ClientProvider);
+
+                var connection1 = HubConnectionContextUtils.Create(client1.Connection);
+
+                await manager.OnConnectedAsync(connection1).OrTimeout();
+
+                await manager.SendAllAsync("Hello", new object[] { "World" }).OrTimeout();
+
+                await AssertMessageAsync(client1);
+            }
+        }
+
+        [Fact]
+        public async Task Hub_NonInterfaceMatchingNaming_Output()
+        {
+            using (var client1 = new TestClient())
+            {
+                var manager = new OrleansHubLifetimeManager<DaHubx>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<DaHubx>>(), _fixture.ClientProvider);
+
+                var connection1 = HubConnectionContextUtils.Create(client1.Connection);
+
+                await manager.OnConnectedAsync(connection1).OrTimeout();
+
+                await manager.SendAllAsync("Hello", new object[] { "World" }).OrTimeout();
+
+                await AssertMessageAsync(client1);
+            }
+        }
+
+        [Fact]
+        public async Task HubUsingGenericBase_NonInterfaceMatchingNaming_Output()
+        {
+            using (var client1 = new TestClient())
+            {
+                var manager = new OrleansHubLifetimeManager<DaHubUsingBase>(new LoggerFactory().CreateLogger<OrleansHubLifetimeManager<DaHubUsingBase>>(), _fixture.ClientProvider);
+
+                var connection1 = HubConnectionContextUtils.Create(client1.Connection);
+
+                await manager.OnConnectedAsync(connection1).OrTimeout();
+
+                await manager.SendAllAsync("Hello", new object[] { "World" }).OrTimeout();
+
+                await AssertMessageAsync(client1);
+            }
+        }
+
+        [Fact]
         public async Task InvokeAllAsync_DoesNotWriteTo_DisconnectedConnections_Output()
         {
             using (var client1 = new TestClient())


### PR DESCRIPTION

### Fix
- Hub naming now will use the interface name consistently from Orleans and from the SignalR (`OrleansHubLifetimeManager`)

Fixes https://github.com/OrleansContrib/SignalR.Orleans/issues/68

The following are supported:

```ts
public class AppConfigHub : Hub<IAppConfigHub>
```
```ts
public class AppConfigxHub : Hub<IAppConfigHub>
```
```ts
public class AppConfigxHub : OdinHub<IAppConfigHub>
```
