### PR TITLE
fix(hub manager): dispatching messages multiple times

### DIFF
--- a/src/SignalR.Orleans/OrleansHubLifetimeManager.cs
+++ b/src/SignalR.Orleans/OrleansHubLifetimeManager.cs
@@ -23,6 +23,7 @@ namespace SignalR.Orleans
         private IAsyncStream<ClientMessage> _serverStream;
         private IAsyncStream<AllMessage> _allStream;
         private readonly string _hubName;
+        private readonly SemaphoreSlim _streamSetupLock = new SemaphoreSlim(1);
 
         public OrleansHubLifetimeManager(
             ILogger<OrleansHubLifetimeManager<THub>> logger,
@@ -36,6 +37,25 @@ namespace SignalR.Orleans
             _serverId = Guid.NewGuid();
             _logger = logger;
             _clusterClientProvider = clusterClientProvider;
+        }
+
+        private async Task EnsureStreamSetup()
+        {
+            if (_streamProvider != null)
+                return;
+
+            await _streamSetupLock.WaitAsync();
+
+            if (_streamProvider != null)
+                return;
+            try
+            {
+                await SetupStreams();
+            }
+            finally
+            {
+                _streamSetupLock.Release();
+            }
         }
 
         private async Task SetupStreams()
@@ -83,13 +103,10 @@ namespace SignalR.Orleans
 
         public override async Task OnConnectedAsync(HubConnectionContext connection)
         {
+            await EnsureStreamSetup();
+
             try
             {
-                if (_streamProvider == null)
-                {
-                    await SetupStreams();
-                }
-
                 _connections.Add(connection);
 
                 if (connection.User.Identity.IsAuthenticated)

--- a/src/SignalR.Orleans/OrleansHubLifetimeManager.cs
+++ b/src/SignalR.Orleans/OrleansHubLifetimeManager.cs
@@ -37,6 +37,7 @@ namespace SignalR.Orleans
             _serverId = Guid.NewGuid();
             _logger = logger;
             _clusterClientProvider = clusterClientProvider;
+            _ = EnsureStreamSetup();
         }
 
         private async Task EnsureStreamSetup()


### PR DESCRIPTION
Fixes https://github.com/OrleansContrib/SignalR.Orleans/issues/79

@galvesribeiro  Should we also do the eager as the redis one? https://github.com/aspnet/SignalR/blob/master/src/Microsoft.AspNetCore.SignalR.StackExchangeRedis/RedisHubLifetimeManager.cs#L47

Managed to replicate locally and with the fix

### Result
![image](https://user-images.githubusercontent.com/3908723/59207663-c4427600-8ba7-11e9-9260-12b29de4ef97.png)

### Source
![image](https://user-images.githubusercontent.com/3908723/59207672-cad0ed80-8ba7-11e9-88cb-cb012afdc825.png)
(the highlighted log removed it, as its more was used to prove that this works)
