### PR TITLE
feat(generic host): implement UseSignalR for generic host

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ public void ConfigureServices(IServiceCollection services)
 {
   ...
   services
-    .AddSingleton<IClusterClient>(client);
+    .AddSingleton<IClusterClient>(client)
     .AddSignalR()
     .AddOrleans();
   ...

--- a/src/SignalR.Orleans/Constants.cs
+++ b/src/SignalR.Orleans/Constants.cs
@@ -5,6 +5,9 @@ namespace SignalR.Orleans
     public static class Constants
     {
         public const string PUBSUB_PROVIDER = "PubSubStore";
+        // todo: ideally it doesnt use the default name so consumers can replace the provider and not affecting the default - it will be breaking tho.
+        //public const string PUBSUB_PROVIDER = "ORLEANS_SIGNALR_PUBSUB_PROVIDER";
+
         public const string STORAGE_PROVIDER = "ORLEANS_SIGNALR_STORAGE_PROVIDER";
 
         public const string SERVERS_STREAM = "SERVERS_STREAM";

--- a/src/SignalR.Orleans/Extensions.cs
+++ b/src/SignalR.Orleans/Extensions.cs
@@ -6,10 +6,13 @@ using Orleans.Hosting;
 using SignalR.Orleans;
 using SignalR.Orleans.Clients;
 
+// ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.DependencyInjection
 {
     public static class OrleansServerExtensions
     {
+#pragma warning disable 618
+        [Obsolete("Use UseSignalR(this ISiloBuilder builder, Action<SignalrOrleansSiloConfigBuilder> configure = null) from Orleans.Hosting instead.")]
         public static ISiloHostBuilder UseSignalR(this ISiloHostBuilder builder, Action<SignalrServerConfig> config)
         {
             var cfg = new SignalrServerConfig();
@@ -18,10 +21,12 @@ namespace Microsoft.Extensions.DependencyInjection
             return builder.UseSignalR(cfg);
         }
 
-        public static ISiloHostBuilder UseSignalR(this ISiloHostBuilder builder, SignalrServerConfig config = null)
+        [Obsolete("Use UseSignalR(this ISiloBuilder builder, Action<SignalrOrleansSiloConfigBuilder> configure = null) from Orleans.Hosting instead.")]
+        public static ISiloHostBuilder UseSignalR(this ISiloHostBuilder builder, SignalrServerConfig config)
         {
             if (config == null)
                 config = new SignalrServerConfig();
+#pragma warning restore 618
 
             config.ConfigureBuilder?.Invoke(builder, new HostBuilderConfig());
 

--- a/src/SignalR.Orleans/HostingExtensions.cs
+++ b/src/SignalR.Orleans/HostingExtensions.cs
@@ -1,0 +1,73 @@
+using System;
+using SignalR.Orleans;
+using SignalR.Orleans.Clients;
+
+// ReSharper disable once CheckNamespace
+namespace Orleans.Hosting
+{
+    public static class SiloBuilderExtensions
+    {
+        public static ISiloBuilder UseSignalR(this ISiloBuilder builder, Action<SignalrOrleansSiloConfigBuilder> configure = null)
+        {
+            var cfg = new SignalrOrleansSiloConfigBuilder();
+            configure?.Invoke(cfg);
+
+            cfg.ConfigureBuilder?.Invoke(builder, new HostBuilderConfig());
+
+            try
+            {
+                builder.AddMemoryGrainStorage(Constants.PUBSUB_PROVIDER);
+            }
+            catch
+            {
+                /** PubSubStore was already added. Do nothing. **/
+            }
+
+            try
+            {
+                builder.AddMemoryGrainStorage(Constants.STORAGE_PROVIDER);
+            }
+            catch
+            {
+                /** Grain storage provider was already added. Do nothing. **/
+            }
+
+            return builder
+                .AddSimpleMessageStreamProvider(Constants.STREAM_PROVIDER, opt => opt.FireAndForgetDelivery = cfg.UseFireAndForgetDelivery)
+                .ConfigureApplicationParts(parts => parts.AddApplicationPart(typeof(ClientGrain).Assembly).WithReferences());
+        }
+    }
+
+    public static class SiloHostBuilderExtensions
+    {
+        public static ISiloHostBuilder UseSignalR(this ISiloHostBuilder builder, Action<SignalrOrleansSiloHostConfigBuilder> configure = null)
+        {
+            var cfg = new SignalrOrleansSiloHostConfigBuilder();
+            configure?.Invoke(cfg);
+
+            cfg.ConfigureBuilder?.Invoke(builder, new HostBuilderConfig());
+
+            try
+            {
+                builder.AddMemoryGrainStorage(Constants.PUBSUB_PROVIDER);
+            }
+            catch
+            {
+                /** PubSubStore was already added. Do nothing. **/
+            }
+
+            try
+            {
+                builder.AddMemoryGrainStorage(Constants.STORAGE_PROVIDER);
+            }
+            catch
+            {
+                /** Grain storage provider was already added. Do nothing. **/
+            }
+
+            return builder
+                .AddSimpleMessageStreamProvider(Constants.STREAM_PROVIDER, opt => opt.FireAndForgetDelivery = cfg.UseFireAndForgetDelivery)
+                .ConfigureApplicationParts(parts => parts.AddApplicationPart(typeof(ClientGrain).Assembly).WithReferences());
+        }
+    }
+}

--- a/src/SignalR.Orleans/SignalrConfig.cs
+++ b/src/SignalR.Orleans/SignalrConfig.cs
@@ -5,14 +5,57 @@ namespace SignalR.Orleans
 {
     public class HostBuilderConfig
     {
+        /// <summary>
+        /// Gets the storage provider name which is used for registration.
+        /// </summary>
         public string StorageProvider { get; } = Constants.STORAGE_PROVIDER;
+
+        /// <summary>
+        /// Gets the pubsub provider name which is used for registration.
+        /// </summary>
         public string PubSubProvider { get; } = Constants.PUBSUB_PROVIDER;
     }
 
+    [Obsolete("Use SignalrOrleansSiloHostConfigBuilder instead.")]
     public class SignalrServerConfig
     {
         public Action<ISiloHostBuilder, HostBuilderConfig> ConfigureBuilder { get; set; }
         public bool UseFireAndForgetDelivery { get; set; }
+    }
+
+    public class SignalrOrleansConfigBaseBuilder
+    {
+        public bool UseFireAndForgetDelivery { get; set; }
+    }
+
+    public class SignalrOrleansSiloConfigBuilder : SignalrOrleansConfigBaseBuilder
+    {
+        internal Action<ISiloBuilder, HostBuilderConfig> ConfigureBuilder { get; set; }
+
+        /// <summary>
+        /// Configure builder, such as providers.
+        /// </summary>
+        /// <param name="configure">Configure action. This may be called multiple times.</param>
+        public SignalrOrleansSiloConfigBuilder Configure(Action<ISiloBuilder, HostBuilderConfig> configure)
+        {
+            ConfigureBuilder += configure;
+            return this;
+        }
+    }
+
+    public class SignalrOrleansSiloHostConfigBuilder : SignalrOrleansConfigBaseBuilder
+    {
+        internal Action<ISiloHostBuilder, HostBuilderConfig> ConfigureBuilder { get; set; }
+
+        /// <summary>
+        /// Configure builder, such as providers.
+        /// </summary>
+        /// <param name="configure">Configure action. This may be called multiple times.</param>
+        public SignalrOrleansSiloHostConfigBuilder Configure(Action<ISiloHostBuilder, HostBuilderConfig> configure)
+        {
+            ConfigureBuilder += configure;
+            return this;
+        }
     }
 
     public class SignalrClientConfig


### PR DESCRIPTION
### Features
- Add `UseSignalR` for generic host `ISiloBuilder` - fixes https://github.com/OrleansContrib/SignalR.Orleans/issues/69
- Align both `ISiloBuilder` and `ISiloHostBuilder` - now with `.Configure` instead of `Action` exposed
- Moved `ISiloHostBuilder` extension to the correct namespace

### Deprecated Code
- `SignalrServerConfig` has been marked as Obsolete