### PR TITLE
feat(config): auto register pubsub storage configurable

### DIFF
--- a/src/SignalR.Orleans/HostingExtensions.cs
+++ b/src/SignalR.Orleans/HostingExtensions.cs
@@ -14,13 +14,16 @@ namespace Orleans.Hosting
 
             cfg.ConfigureBuilder?.Invoke(builder, new HostBuilderConfig());
 
-            try
+            if (cfg.AutoRegisterPubSubStorage)
             {
-                builder.AddMemoryGrainStorage(Constants.PUBSUB_PROVIDER);
-            }
-            catch
-            {
-                /** PubSubStore was already added. Do nothing. **/
+                try
+                {
+                    builder.AddMemoryGrainStorage(Constants.PUBSUB_PROVIDER);
+                }
+                catch
+                {
+                    /** PubSubStore was already added. Do nothing. **/
+                }
             }
 
             try
@@ -47,13 +50,16 @@ namespace Orleans.Hosting
 
             cfg.ConfigureBuilder?.Invoke(builder, new HostBuilderConfig());
 
-            try
+            if (cfg.AutoRegisterPubSubStorage)
             {
-                builder.AddMemoryGrainStorage(Constants.PUBSUB_PROVIDER);
-            }
-            catch
-            {
-                /** PubSubStore was already added. Do nothing. **/
+                try
+                {
+                    builder.AddMemoryGrainStorage(Constants.PUBSUB_PROVIDER);
+                }
+                catch
+                {
+                    /** PubSubStore was already added. Do nothing. **/
+                }
             }
 
             try

--- a/src/SignalR.Orleans/SignalrConfig.cs
+++ b/src/SignalR.Orleans/SignalrConfig.cs
@@ -26,6 +26,11 @@ namespace SignalR.Orleans
     public class SignalrOrleansConfigBaseBuilder
     {
         public bool UseFireAndForgetDelivery { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether 'PubSub' storage is auto registered as memory or not (defaults: true).
+        /// </summary>
+        public bool AutoRegisterPubSubStorage { get; set; } = true;
     }
 
     public class SignalrOrleansSiloConfigBuilder : SignalrOrleansConfigBaseBuilder


### PR DESCRIPTION
### Features
**config:** configurable auto register pubsub

Mainly this was added as I had a teething issue due to it, basically, storage grain such as redis/dynamodb weren't working due to this, and the only option had to move `UseSignalR` further down the chain otherwise it throws a weird exception.

To be honest, I think the auto-register `PubSub` might not be a good idea since then configuring PubSub afterwards seems to be causing issues