### PR TITLE
Updated Orleans to 2.4.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -32,11 +32,11 @@
   <!-- Shared Package Versions -->
   <PropertyGroup>
     <!-- vendors -->
-    <OrleansCoreVersion>2.3.4</OrleansCoreVersion>
-    <OrleansProvidersVersion>2.3.4</OrleansProvidersVersion>
-    <OrleansCodeGeneratorVersion>2.3.4</OrleansCodeGeneratorVersion>
-    <OrleansRuntimeAbstractionsVersion>2.3.4</OrleansRuntimeAbstractionsVersion>
-    <OrleansRuntimeVersion>2.3.4</OrleansRuntimeVersion>
+    <OrleansCoreVersion>2.4.0</OrleansCoreVersion>
+    <OrleansProvidersVersion>2.4.0</OrleansProvidersVersion>
+    <OrleansCodeGeneratorVersion>2.4.0</OrleansCodeGeneratorVersion>
+    <OrleansRuntimeAbstractionsVersion>2.4.0</OrleansRuntimeAbstractionsVersion>
+    <OrleansRuntimeVersion>2.4.0</OrleansRuntimeVersion>
     <SignalRVersion>1.1.0</SignalRVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Recently release at: 
https://github.com/dotnet/orleans/releases/tag/v2.4.0

2.4.0 is fully backwards compatible with 2.0.* releases.

- [x] Tests Passing
- [ ] Tested in an orleans cluster with multiple silos and multiple signalr servers