### PR TITLE
Defer stream setup to address crashing co-hosted services

### DIFF
--- a/src/SignalR.Orleans/OrleansHubLifetimeManager.cs
+++ b/src/SignalR.Orleans/OrleansHubLifetimeManager.cs
@@ -39,7 +39,6 @@ namespace SignalR.Orleans
             _serverId = Guid.NewGuid();
             _logger = logger;
             _clusterClientProvider = clusterClientProvider;
-            _ = EnsureStreamSetup();
         }
 
         private Task HeartbeatCheck()


### PR DESCRIPTION
When using a co-hosted `IClusterClient` (that is: your Orleans silo and client are hosted by the same application), the early invocation of `EnsureStreamSetup` can cause Orleans to crash with the error `Orleans.Runtime.Scheduler.OrleansTaskScheduler: Error: QueueWorkItem was called on a non-null context [SystemTarget: S127.0.0.1:11111:313726326*stg/14/0000000e@S0000000e] but there is no valid WorkItemGroup for it.`

I believe this is due the fact that the client is trying to set up the streams before the Orleans server is alive. This isn't a problem on networked silos because you wouldn't be able to establish a connection to the silo before it is initialized.

The fix seems to be to simply defer stream set up. This fix has not been tested in a production environment. I'm not familiar with the internals of this service. Please let me know if you think this is an acceptable fix.