### PR TITLE
Fix internal stream initialization

### DIFF
--- a/README.Nuget.md
+++ b/README.Nuget.md
@@ -1,14 +1,47 @@
+
+[![Build](https://github.com/OrleansContrib/SignalR.Orleans/workflows/CI/badge.svg)](https://github.com/OrleansContrib/SignalR.Orleans/actions)
+[![Package Version](https://img.shields.io/nuget/v/SignalR.Orleans.svg)](https://www.nuget.org/packages/SignalR.Orleans)
+[![NuGet Downloads](https://img.shields.io/nuget/dt/SignalR.Orleans.svg)](https://www.nuget.org/packages/SignalR.Orleans)
+[![License](https://img.shields.io/github/license/OrleansContrib/SignalR.Orleans.svg)](https://github.com/OrleansContrib/SignalR.Orleans/blob/master/LICENSE)
+[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/dotnet/orleans?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+
+[Orleans](https://github.com/dotnet/orleans) is a framework that provides a straight-forward approach to building distributed high-scale computing applications, without the need to learn and apply complex concurrency or other scaling patterns. 
+
+[ASP.NET Core SignalR](https://github.com/aspnet/SignalR) is a new library for ASP.NET Core developers that makes it incredibly simple to add real-time web functionality to your applications. What is "real-time web" functionality? It's the ability to have your server-side code push content to the connected clients as it happens, in real-time.
+
+**SignalR.Orleans** is a package that allow us to enhance the _real-time_ capabilities of SignalR by leveraging Orleans distributed cloud platform capabilities.
+
+
+# Installation
+
+Installation is performed via [NuGet](https://www.nuget.org/packages/SignalR.Orleans/)
+
+From Package Manager:
+
+> PS> Install-Package SignalR.Orleans
+
+.Net CLI:
+
+> \# dotnet add package SignalR.Orleans
+
+Paket:
+
+> \# paket add SignalR.Orleans
+
 # Configuration
 
 ## Silo
 We need to configure the Orleans Silo with the below:
 * Use `.UseSignalR()` on `ISiloHostBuilder`.
+* Make sure to call `RegisterHub<THub>()` where `THub` is the type of the Hub you want to be added to the backplane.
 
 ***Example***
 ```cs
 var silo = new SiloHostBuilder()
-    .UseSignalR()
-    .Build();
+  .UseSignalR()
+  .RegisterHub<MyHub>() // You need to call this per `Hub` type.
+  .AddMemoryGrainStorage("PubSubStore") // You can use any other storage provider as long as you have one registered as "PubSubStore".
+  .Build();
 
 await silo.StartAsync();
 ```
@@ -20,13 +53,14 @@ Optional configuration to override the default implementation for both providers
 ```cs
 .UseSignalR(cfg =>
 {
-    cfg.ConfigureBuilder = (builder, config) =>
-    {
-        builder
-            .AddMemoryGrainStorage(config.PubSubProvider)
-            .AddMemoryGrainStorage(config.StorageProvider);
-    };
+  cfg.ConfigureBuilder = (builder, config) =>
+  {
+    builder
+      .AddMemoryGrainStorage(config.PubSubProvider)
+      .AddMemoryGrainStorage(config.StorageProvider);
+  };
 })
+.RegisterHub<MyHub>()
 ```
 
 ## Client
@@ -36,13 +70,14 @@ Now your SignalR application needs to connect to the Orleans Cluster by using an
 ***Example***
 ```cs
 var client = new ClientBuilder()
-    .UseSignalR()
-    .Build();
+  .UseSignalR()
+  .Build();
 
 await client.Connect();
 ```
 
 Somewhere in your `Startup.cs`:
+* Add `IClusterClient` (created in the above example) to `IServiceCollection`.
 * Use `.AddSignalR()` on `IServiceCollection` (this is part of `Microsoft.AspNetCore.SignalR` nuget package).
 * Use `AddOrleans()` on `.AddSignalR()`.
 
@@ -50,11 +85,12 @@ Somewhere in your `Startup.cs`:
 ```cs
 public void ConfigureServices(IServiceCollection services)
 {
-    ...
-    services
-        .AddSignalR()
-        .AddOrleans();
-    ...
+  ...
+  services
+    .AddSingleton<IClusterClient>(client)
+    .AddSignalR()
+    .AddOrleans();
+  ...
 }
 ```
 Great! Now you have SignalR configured and Orleans SignalR backplane built in Orleans!
@@ -69,13 +105,16 @@ Sample usage: Receiving server push notifications from message brokers, web hook
 ```cs
 public class UserNotificationGrain : Grain<UserNotificationState>, IUserNotificationGrain
 {
-    private HubContext<IUserNotificationHub> _hubContext;
+  private HubContext<IUserNotificationHub> _hubContext;
 
-    public override async Task OnActivateAsync()
-    {
-        _hubContext = GrainFactory.GetHub<IUserNotificationHub>();
-        // some code...
-        await _hubContext.User(this.GetPrimaryKeyString()).Send("Broadcast", State.UserNotification);
-    }
+  public override async Task OnActivateAsync()
+  {
+    _hubContext = GrainFactory.GetHub<IUserNotificationHub>();
+    // some code...
+    await _hubContext.User(this.GetPrimaryKeyString()).Send("Broadcast", State.UserNotification);
+  }
 }
 ```
+
+# Contributions
+PRs and feedback are **very** welcome!

--- a/README.md
+++ b/README.md
@@ -37,11 +37,13 @@ Paket:
 ## Silo
 We need to configure the Orleans Silo with the below:
 * Use `.UseSignalR()` on `ISiloHostBuilder`.
+* Make sure to call `RegisterHub<THub>()` where `THub` is the type of the Hub you want to be added to the backplane.
 
 ***Example***
 ```cs
 var silo = new SiloHostBuilder()
   .UseSignalR()
+  .RegisterHub<MyHub>() // You need to call this per `Hub` type.
   .AddMemoryGrainStorage("PubSubStore") // You can use any other storage provider as long as you have one registered as "PubSubStore".
   .Build();
 
@@ -62,6 +64,7 @@ Optional configuration to override the default implementation for both providers
       .AddMemoryGrainStorage(config.StorageProvider);
   };
 })
+.RegisterHub<MyHub>()
 ```
 
 ## Client

--- a/src/SignalR.Orleans/HostingExtensions.cs
+++ b/src/SignalR.Orleans/HostingExtensions.cs
@@ -5,50 +5,88 @@ using Orleans.Storage;
 using SignalR.Orleans;
 using SignalR.Orleans.Clients;
 using System;
+using Microsoft.AspNetCore.SignalR;
 
 // ReSharper disable once CheckNamespace
 namespace Orleans.Hosting
 {
     public static class SiloBuilderExtensions
     {
-        public static ISiloBuilder UseSignalR(this ISiloBuilder builder, Action<SignalrOrleansSiloConfigBuilder> configure = null)
+        public static ISiloBuilder UseSignalR(this ISiloBuilder builder,
+            Action<SignalrOrleansSiloConfigBuilder> configure = null)
         {
             var cfg = new SignalrOrleansSiloConfigBuilder();
             configure?.Invoke(cfg);
 
             cfg.ConfigureBuilder?.Invoke(builder, new HostBuilderConfig());
 
-            try { builder.AddMemoryGrainStorage(Constants.PUBSUB_PROVIDER); }
-            catch { /** PubSubStore was already added. Do nothing. **/ }
+            try
+            {
+                builder.AddMemoryGrainStorage(Constants.PUBSUB_PROVIDER);
+            }
+            catch
+            {
+                /** PubSubStore was already added. Do nothing. **/
+            }
 
-            try { builder.AddMemoryGrainStorage(Constants.STORAGE_PROVIDER); }
-            catch { /** Grain storage provider was already added. Do nothing. **/ }
+            try
+            {
+                builder.AddMemoryGrainStorage(Constants.STORAGE_PROVIDER);
+            }
+            catch
+            {
+                /** Grain storage provider was already added. Do nothing. **/
+            }
 
-            builder.ConfigureServices(services => services.AddSingleton<IConfigurationValidator, SignalRConfigurationValidator>());
+            builder.ConfigureServices(services =>
+                services.AddSingleton<IConfigurationValidator, SignalRConfigurationValidator>());
 
             return builder
-                .AddSimpleMessageStreamProvider(Constants.STREAM_PROVIDER, opt => opt.FireAndForgetDelivery = cfg.UseFireAndForgetDelivery)
-                .ConfigureApplicationParts(parts => parts.AddApplicationPart(typeof(ClientGrain).Assembly).WithReferences());
+                .AddSimpleMessageStreamProvider(Constants.STREAM_PROVIDER,
+                    opt => opt.FireAndForgetDelivery = cfg.UseFireAndForgetDelivery)
+                .ConfigureApplicationParts(parts =>
+                    parts.AddApplicationPart(typeof(ClientGrain).Assembly).WithReferences());
+        }
+
+        public static ISiloBuilder RegisterHub<THub>(this ISiloBuilder builder) where THub : Hub
+        {
+            builder.ConfigureServices(services =>
+            {
+                services.AddTransient<ILifecycleParticipant<ISiloLifecycle>>(sp =>
+                    sp.GetRequiredService<HubLifetimeManager<THub>>() as ILifecycleParticipant<ISiloLifecycle>);
+            });
+
+            return builder;
         }
     }
 
     public static class SiloHostBuilderExtensions
     {
-        public static ISiloHostBuilder UseSignalR(this ISiloHostBuilder builder, Action<SignalrOrleansSiloHostConfigBuilder> configure = null)
+        public static ISiloHostBuilder UseSignalR(this ISiloHostBuilder builder,
+            Action<SignalrOrleansSiloHostConfigBuilder> configure = null)
         {
             var cfg = new SignalrOrleansSiloHostConfigBuilder();
             configure?.Invoke(cfg);
 
             cfg.ConfigureBuilder?.Invoke(builder, new HostBuilderConfig());
 
-            try { builder.AddMemoryGrainStorage(Constants.STORAGE_PROVIDER); }
-            catch { /** Grain storage provider was already added. Do nothing. **/ }
+            try
+            {
+                builder.AddMemoryGrainStorage(Constants.STORAGE_PROVIDER);
+            }
+            catch
+            {
+                /** Grain storage provider was already added. Do nothing. **/
+            }
 
-            builder.ConfigureServices(services => services.AddSingleton<IConfigurationValidator, SignalRConfigurationValidator>());
+            builder.ConfigureServices(services =>
+                services.AddSingleton<IConfigurationValidator, SignalRConfigurationValidator>());
 
             return builder
-                .AddSimpleMessageStreamProvider(Constants.STREAM_PROVIDER, opt => opt.FireAndForgetDelivery = cfg.UseFireAndForgetDelivery)
-                .ConfigureApplicationParts(parts => parts.AddApplicationPart(typeof(ClientGrain).Assembly).WithReferences());
+                .AddSimpleMessageStreamProvider(Constants.STREAM_PROVIDER,
+                    opt => opt.FireAndForgetDelivery = cfg.UseFireAndForgetDelivery)
+                .ConfigureApplicationParts(parts =>
+                    parts.AddApplicationPart(typeof(ClientGrain).Assembly).WithReferences());
         }
     }
 
@@ -59,7 +97,8 @@ namespace Orleans.Hosting
 
         public SignalRConfigurationValidator(IServiceProvider serviceProvider)
         {
-            this._logger = serviceProvider.GetRequiredService<ILoggerFactory>().CreateLogger<SignalRConfigurationValidator>();
+            this._logger = serviceProvider.GetRequiredService<ILoggerFactory>()
+                .CreateLogger<SignalRConfigurationValidator>();
             this._sp = serviceProvider;
         }
 
@@ -70,12 +109,14 @@ namespace Orleans.Hosting
             var pubSubProvider = this._sp.GetServiceByName<IGrainStorage>(Constants.PUBSUB_PROVIDER);
             if (pubSubProvider == null)
             {
-                var err = "No PubSub storage provider was registered. You need to register one. To use the default/in-memory provider, call 'siloBuilder.AddMemoryGrainStorage(\"PubSubStore\")' when building your Silo.";
+                var err =
+                    "No PubSub storage provider was registered. You need to register one. To use the default/in-memory provider, call 'siloBuilder.AddMemoryGrainStorage(\"PubSubStore\")' when building your Silo.";
                 this._logger.LogError(err);
                 throw new InvalidOperationException(err);
             }
 
-            this._logger.LogInformation($"Found the PubSub storage provider of type '{pubSubProvider.GetType().FullName}'.");
+            this._logger.LogInformation(
+                $"Found the PubSub storage provider of type '{pubSubProvider.GetType().FullName}'.");
         }
     }
 }


### PR DESCRIPTION
We used to have a hack that creates a non-awaited `Task` when initializing it. It was always a gray area which was never fixed.

Now we hook the stream initialization per `THub` into Orleans Lifecycle.

*Breaking Change*

Now you are required to call `ISiloBuilder.RegisterHub<THub>()` per hub in order to startup the backplane correctly.