### PR TITLE
Adds HubUtility to resolve hub names. 

### DIFF
--- a/src/SignalR.Orleans/Core/GrainExtensions.cs
+++ b/src/SignalR.Orleans/Core/GrainExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.SignalR;
 using Microsoft.AspNetCore.SignalR.Protocol;
 using Orleans.Concurrency;
 using SignalR.Orleans.Core;
@@ -37,7 +38,7 @@ namespace Orleans
 
     public static class GrainFactoryExtensions
     {
-        public static HubContext<THub> GetHub<THub>(this IGrainFactory grainFactory)
+        public static HubContext<THub> GetHub<THub>(this IGrainFactory grainFactory) where THub : Hub
         {
             return new HubContext<THub>(grainFactory);
         }

--- a/src/SignalR.Orleans/Core/HubContext.cs
+++ b/src/SignalR.Orleans/Core/HubContext.cs
@@ -1,11 +1,12 @@
-﻿using Orleans;
+﻿using Microsoft.AspNetCore.SignalR;
+using Orleans;
 using SignalR.Orleans.Users;
 using SignalR.Orleans.Groups;
 using SignalR.Orleans.Clients;
 
 namespace SignalR.Orleans.Core
 {
-    public class HubContext<THub>
+    public class HubContext<THub> where THub : Hub
     {
         private readonly IGrainFactory _grainFactory;
         private readonly string _hubName;
@@ -13,10 +14,7 @@ namespace SignalR.Orleans.Core
         public HubContext(IGrainFactory grainFactory)
         {
             _grainFactory = grainFactory;
-            var hubType = typeof(THub);
-            _hubName = hubType.IsInterface && hubType.Name.StartsWith("I")
-                ? hubType.Name.Substring(1)
-                : hubType.Name;
+            _hubName = HubUtility.GetHubName<THub>();
         }
 
         public IClientGrain Client(string connectionId) => _grainFactory.GetClientGrain(_hubName, connectionId);

--- a/src/SignalR.Orleans/HubUtility.cs
+++ b/src/SignalR.Orleans/HubUtility.cs
@@ -1,0 +1,11 @@
+﻿using Microsoft.AspNetCore.SignalR;
+
+namespace SignalR.Orleans;
+
+internal static class HubUtility
+{
+    internal static string GetHubName<THub>() where THub : Hub
+    {
+        return typeof(THub).Name;
+    }
+}

--- a/src/SignalR.Orleans/OrleansHubLifetimeManager.cs
+++ b/src/SignalR.Orleans/OrleansHubLifetimeManager.cs
@@ -34,11 +34,7 @@ namespace SignalR.Orleans
             IClusterClientProvider clusterClientProvider
         )
         {
-            var hubType = typeof(THub).BaseType?.GenericTypeArguments.FirstOrDefault() ?? typeof(THub);
-            var name = hubType.Name.AsSpan();
-            _hubName = hubType.IsInterface && name[0] == 'I'
-                ? new string(name.Slice(1))
-                : hubType.Name;
+            _hubName = HubUtility.GetHubName<THub>();
             _serverId = Guid.NewGuid();
             _logger = logger;
             _clusterClientProvider = clusterClientProvider;

--- a/test/SignalR.Orleans.Tests/HubUtilityTests.cs
+++ b/test/SignalR.Orleans.Tests/HubUtilityTests.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.AspNetCore.SignalR;
+using Xunit;
+
+namespace SignalR.Orleans.Tests
+{
+    public class HubUtilityTests
+    {
+        [Fact]
+        public void GivenAWeaklyTypedHub_WhenGetHubName_ThenReturnsHubName()
+        {
+            var result = HubUtility.GetHubName<MyWeaklyTypedHub>();
+
+            Assert.Equal("MyWeaklyTypedHub", result);
+        }
+
+        [Fact]
+        public void GivenAStronglyTypedHub_WhenGetHubName_ThenReturnsHubName()
+        {
+            var result = HubUtility.GetHubName<MyStronglyTypedHub>();
+
+            Assert.Equal("MyStronglyTypedHub", result);
+        }
+
+        private class MyWeaklyTypedHub : Hub
+        {
+        }
+
+        private interface IHubClient
+        {
+        }
+
+        private class MyStronglyTypedHub : Hub<IHubClient>
+        {
+        }
+    }
+}


### PR DESCRIPTION
Keeps HubContext name resolution consistent with OrleansHubLifetimeManager.

I understand this could be breaking to some consumers of the library.  However, I thought Id' raise the PR to get the conversation going.

In my opinion, the OrleansHubLifetimeManager should not look for the typed client of the hub when resolving the hub name but maybe I am missing something.

I've also brought the HubContext in line with the actual implementation of hub context which will ensure consistency between the HubContext and OrleansHubLifetimeManager. 

From MSDN:
`public interface IHubContext<out THub> where THub : Hub`
Ref:
https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.signalr.ihubcontext-1?view=aspnetcore-6.0

