### PR TITLE
Remove ArrayPool in ClientGrain.OnActivateAsync and replace with new allocated array

### DIFF
--- a/src/SignalR.Orleans/Clients/ClientGrain.cs
+++ b/src/SignalR.Orleans/Clients/ClientGrain.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Buffers;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -63,7 +62,6 @@ namespace SignalR.Orleans.Clients
             }
 
             await Task.WhenAll(subscriptionTasks);
-            ArrayPool<Task>.Shared.Return(subscriptionTasks);
         }
 
         public async Task Send(Immutable<InvocationMessage> message)

--- a/src/SignalR.Orleans/Clients/ClientGrain.cs
+++ b/src/SignalR.Orleans/Clients/ClientGrain.cs
@@ -55,7 +55,7 @@ namespace SignalR.Orleans.Clients
             _serverStream = _streamProvider.GetStream<ClientMessage>(_clientState.State.ServerId, Constants.SERVERS_STREAM);
             _serverDisconnectedStream = _streamProvider.GetStream<Guid>(_clientState.State.ServerId, Constants.SERVER_DISCONNECTED);
             var subscriptions = await _serverDisconnectedStream.GetAllSubscriptionHandles();
-            var subscriptionTasks = ArrayPool<Task>.Shared.Rent(subscriptions.Count);
+            var subscriptionTasks = new Task[subscriptions.Count];
             for (int i = 0; i < subscriptions.Count; i++)
             {
                 var subscription = subscriptions[i];


### PR DESCRIPTION
ArrayPool returns an array which is at least the requested length, and so can have null elements at the end. Task.WhenAll throws an exception when provided an array with nulls.

Replaces #133 which is fixing the same issue but by keeping the arraypool and filtering out the nulls.

This solves #128 