### PR TITLE
UseSignalR() should not call AddApplicationPart()

### DIFF
--- a/README.Nuget.md
+++ b/README.Nuget.md
@@ -71,6 +71,7 @@ Now your SignalR application needs to connect to the Orleans Cluster by using an
 ```cs
 var client = new ClientBuilder()
   .UseSignalR()
+  // optional: .ConfigureApplicationParts(parts => parts.AddApplicationPart(typeof(IClientGrain).Assembly).WithReferences())
   .Build();
 
 await client.Connect();

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Now your SignalR application needs to connect to the Orleans Cluster by using an
 ```cs
 var client = new ClientBuilder()
   .UseSignalR()
+  // optional: .ConfigureApplicationParts(parts => parts.AddApplicationPart(typeof(IClientGrain).Assembly).WithReferences())
   .Build();
 
 await client.Connect();

--- a/src/SignalR.Orleans/HostingExtensions.cs
+++ b/src/SignalR.Orleans/HostingExtensions.cs
@@ -59,8 +59,7 @@ namespace Orleans.Hosting
             if (config == null)
                 config = new SignalrClientConfig();
 
-            return builder.AddSimpleMessageStreamProvider(Constants.STREAM_PROVIDER, opt => opt.FireAndForgetDelivery = config.UseFireAndForgetDelivery)
-                .ConfigureApplicationParts(parts => parts.AddApplicationPart(typeof(IClientGrain).Assembly).WithReferences());
+            return builder.AddSimpleMessageStreamProvider(Constants.STREAM_PROVIDER, opt => opt.FireAndForgetDelivery = config.UseFireAndForgetDelivery);
         }
     }
 

--- a/test/SignalR.Orleans.Tests/OrleansFixture.cs
+++ b/test/SignalR.Orleans.Tests/OrleansFixture.cs
@@ -27,6 +27,7 @@ namespace SignalR.Orleans.Tests
                 .UseLocalhostClustering()
                 .Configure<EndpointOptions>(options => options.AdvertisedIPAddress = IPAddress.Loopback)
                 .UseSignalR()
+                .ConfigureApplicationParts(parts => parts.AddApplicationPart(typeof(IClientGrain).Assembly).WithReferences())
                 .Build();
 
             client.Connect().Wait();


### PR DESCRIPTION
Fixes #137

Removes one line of code from the library, adds one line of code to the test fixture, updates the readme and nuget readme, in order to give callers of the library freedom to decide whether they want to use the default automatic grain type registration logic provided by Orleans or whether they want to explicitly register their grain types themselves.