### PR TITLE
Suppress exceptions from HubLifetimeManager.Dispose()

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   pull_request:
     branches:
-      - master
+      - 3.x
 
 jobs:
   build:

--- a/src/SignalR.Orleans/Clients/ClientGrain.cs
+++ b/src/SignalR.Orleans/Clients/ClientGrain.cs
@@ -1,12 +1,13 @@
 using System;
 using System.Diagnostics;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Logging;
 using Microsoft.AspNetCore.SignalR.Protocol;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Orleans;
+using Orleans.Concurrency;
 using Orleans.Runtime;
 using Orleans.Streams;
-using Orleans.Concurrency;
 using SignalR.Orleans.Core;
 
 namespace SignalR.Orleans.Clients
@@ -36,10 +37,11 @@ namespace SignalR.Orleans.Clients
 
         public ClientGrain(
             ILogger<ClientGrain> logger,
-            [PersistentState(CLIENT_STORAGE, Constants.STORAGE_PROVIDER)] IPersistentState<ClientState> clientState)
+            [PersistentState(CLIENT_STORAGE, Constants.STORAGE_PROVIDER)] IPersistentState<ClientState> clientState,
+            IOptions<InternalOptions> options)
         {
             _logger = logger;
-            _clientState = clientState;
+            _clientState = options.Value.ConflateStorageAccess ? clientState.WithConflation() : clientState;
         }
 
         public override async Task OnActivateAsync()

--- a/src/SignalR.Orleans/Core/ConflatedPersistentState.cs
+++ b/src/SignalR.Orleans/Core/ConflatedPersistentState.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using System.Threading.Tasks;
+using Orleans.Runtime;
+
+namespace SignalR.Orleans.Core;
+
+/// <summary>
+/// A wrapper around the orleans persistent state component that batches operations in a reentrant-safe way to enable optimal throughput.
+/// </summary>
+internal class ConflatedPersistentState<TState> : IPersistentState<TState>
+{
+    public ConflatedPersistentState(IPersistentState<TState> state)
+    {
+        _state = state;
+    }
+
+    private readonly IPersistentState<TState> _state;
+    private Task? _outstanding;
+
+    public TState State
+    {
+        get => _state.State;
+        set => _state.State = value;
+    }
+
+    public string Etag => _state.Etag;
+
+    public bool RecordExists => _state.RecordExists;
+
+    public Task ReadStateAsync() => ConflateStateAsync(OperationType.Read);
+
+    public Task ClearStateAsync() => ConflateStateAsync(OperationType.Clear);
+
+    public Task WriteStateAsync() => ConflateStateAsync(OperationType.Write);
+
+    private async Task ConflateStateAsync(OperationType type)
+    {
+        var outstanding = _outstanding;
+        if (outstanding != null)
+        {
+            try
+            {
+                await outstanding;
+            }
+            catch
+            {
+                // noop
+            }
+            finally
+            {
+                if (_outstanding == outstanding)
+                {
+                    _outstanding = null;
+                }
+            }
+        }
+
+        if (_outstanding == null)
+        {
+            outstanding = type switch
+            {
+                OperationType.Read => _state.ReadStateAsync(),
+                OperationType.Write => _state.WriteStateAsync(),
+                OperationType.Clear => _state.ClearStateAsync(),
+                _ => throw new ArgumentOutOfRangeException(nameof(type))
+            };
+
+            _outstanding = outstanding;
+        }
+        else
+        {
+            outstanding = _outstanding;
+        }
+
+        try
+        {
+            await outstanding;
+        }
+        finally
+        {
+            if (_outstanding == outstanding)
+            {
+                _outstanding = null;
+            }
+        }
+    }
+
+    private enum OperationType
+    {
+        Read,
+        Write,
+        Clear
+    }
+}
+
+internal static class ConflatedPersistentStateExtensions
+{
+    public static IPersistentState<TState> WithConflation<TState>(this IPersistentState<TState> state)
+    {
+        if (state is null) throw new ArgumentNullException(nameof(state));
+
+        return new ConflatedPersistentState<TState>(state);
+    }
+}

--- a/src/SignalR.Orleans/Core/ConnectionGrain.cs
+++ b/src/SignalR.Orleans/Core/ConnectionGrain.cs
@@ -1,13 +1,14 @@
-﻿using System.Linq;
-using System.Buffers;
-using System.Threading.Tasks;
+﻿using System.Buffers;
 using System.Collections.Generic;
-using Microsoft.Extensions.Logging;
+using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR.Protocol;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Orleans;
-using Orleans.Streams;
-using Orleans.Runtime;
 using Orleans.Concurrency;
+using Orleans.Runtime;
+using Orleans.Streams;
 
 namespace SignalR.Orleans.Core
 {
@@ -23,10 +24,11 @@ namespace SignalR.Orleans.Core
 
         internal ConnectionGrain(
             ILogger logger,
-            IPersistentState<TGrainState> connectionState)
+            IPersistentState<TGrainState> connectionState,
+            IOptions<InternalOptions> options)
         {
             _logger = logger;
-            _connectionState = connectionState;
+            _connectionState = options.Value.ConflateStorageAccess ? connectionState.WithConflation() : connectionState;
         }
 
         public override async Task OnActivateAsync()

--- a/src/SignalR.Orleans/Core/InternalOptions.cs
+++ b/src/SignalR.Orleans/Core/InternalOptions.cs
@@ -1,0 +1,9 @@
+﻿namespace SignalR.Orleans.Core;
+
+/// <summary>
+/// This internal options class is here to avoid breaking the existing signature of UseSignalR()
+/// </summary>
+internal class InternalOptions
+{
+    public bool ConflateStorageAccess { get; set; } = false;
+}

--- a/src/SignalR.Orleans/Groups/GroupGrain.cs
+++ b/src/SignalR.Orleans/Groups/GroupGrain.cs
@@ -1,6 +1,7 @@
-using Orleans.Runtime;
-using Orleans.Concurrency;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Orleans.Concurrency;
+using Orleans.Runtime;
 using SignalR.Orleans.Core;
 
 namespace SignalR.Orleans.Groups
@@ -11,8 +12,9 @@ namespace SignalR.Orleans.Groups
         private const string GROUP_STORAGE = "GroupState";
         public GroupGrain(
             ILogger<GroupGrain> logger,
-            [PersistentState(GROUP_STORAGE, Constants.STORAGE_PROVIDER)] IPersistentState<GroupState> groupState)
-            : base(logger, groupState)
+            [PersistentState(GROUP_STORAGE, Constants.STORAGE_PROVIDER)] IPersistentState<GroupState> groupState,
+            IOptions<InternalOptions> options)
+            : base(logger, groupState, options)
         {
         }
     }

--- a/src/SignalR.Orleans/HostingExtensions.cs
+++ b/src/SignalR.Orleans/HostingExtensions.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using SignalR.Orleans;
 using SignalR.Orleans.Clients;
+using SignalR.Orleans.Core;
 
 // ReSharper disable once CheckNamespace
 namespace Orleans.Hosting
@@ -106,7 +107,14 @@ namespace Orleans.Hosting
             }
 
             builder.ConfigureServices(services =>
-                services.AddSingleton<IConfigurationValidator, SignalRConfigurationValidator>());
+            {
+                services
+                    .AddSingleton<IConfigurationValidator, SignalRConfigurationValidator>()
+                    .Configure<InternalOptions>(options =>
+                    {
+                        options.ConflateStorageAccess = cfg.ConflateStorageAccess;
+                    });
+            });
 
             return builder
                 .AddSimpleMessageStreamProvider(Constants.STREAM_PROVIDER,
@@ -147,7 +155,14 @@ namespace Orleans.Hosting
             }
 
             builder.ConfigureServices(services =>
-                services.AddSingleton<IConfigurationValidator, SignalRConfigurationValidator>());
+            {
+                services
+                    .AddSingleton<IConfigurationValidator, SignalRConfigurationValidator>()
+                    .Configure<InternalOptions>(options =>
+                    {
+                        options.ConflateStorageAccess = cfg.ConflateStorageAccess;
+                    });
+            });
 
             return builder
                 .AddSimpleMessageStreamProvider(Constants.STREAM_PROVIDER,

--- a/src/SignalR.Orleans/SignalrConfig.cs
+++ b/src/SignalR.Orleans/SignalrConfig.cs
@@ -26,6 +26,8 @@ namespace SignalR.Orleans
     public class SignalrOrleansConfigBaseBuilder
     {
         public bool UseFireAndForgetDelivery { get; set; }
+
+        public bool ConflateStorageAccess { get; } = false;
     }
 
     public class SignalrOrleansSiloConfigBuilder : SignalrOrleansConfigBaseBuilder

--- a/src/SignalR.Orleans/Users/UserGrain.cs
+++ b/src/SignalR.Orleans/Users/UserGrain.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.Logging;
-using Orleans.Runtime;
+using Microsoft.Extensions.Options;
 using Orleans.Concurrency;
+using Orleans.Runtime;
 using SignalR.Orleans.Core;
 
 namespace SignalR.Orleans.Users
@@ -11,8 +12,9 @@ namespace SignalR.Orleans.Users
         private const string USER_STORAGE = "UserState";
         public UserGrain(
             ILogger<UserGrain> logger,
-            [PersistentState(USER_STORAGE, Constants.STORAGE_PROVIDER)] IPersistentState<UserState> userState)
-            : base(logger, userState)
+            [PersistentState(USER_STORAGE, Constants.STORAGE_PROVIDER)] IPersistentState<UserState> userState,
+            IOptions<InternalOptions> options)
+            : base(logger, userState, options)
         {
         }
     }


### PR DESCRIPTION
This PR suppresses exceptions being thrown from `OrleansHubLifetimeManager<T>` while disposing itself.
It also implements the full async disposable pattern as to be more friendly with the NET6+ Service Provider.

The reason for this PR is that this was causing a red herring for us, by hiding the root cause of another issue that was preventing a silo from starting.

Please note that this PR is based on #156 as we already have that in production. Therefore please address that one first.