### PR TITLE
fix: tolerate missing/invalidated stream subscription handles in grain activation

### DIFF
--- a/src/SignalR.Orleans/Clients/ClientGrain.cs
+++ b/src/SignalR.Orleans/Clients/ClientGrain.cs
@@ -49,9 +49,23 @@ internal sealed class ClientGrain : IGrainBase, IClientGrain
         if (_serverId != default)
         {
             // We will listen to this stream to know if the server is disconnected (silo goes down) so that we can enact client disconnected procedure.
-            var serverDisconnectedStream = _streamProvider.GetServerDisconnectionStream(_clientState.State.ServerId);
-            var _serverDisconnectedSubscription = (await serverDisconnectedStream.GetAllSubscriptionHandles())[0];
-            await _serverDisconnectedSubscription.ResumeAsync((serverId, _) => OnDisconnect("server-disconnected"));
+            _serverDisconnectedSubscription = await GetSubscriptionHandleAsync(_serverId);
+            if (_serverDisconnectedSubscription is not null)
+            {
+                // ResumeAsync invalidates the handle it is called on and returns a NEW live handle.
+                // We must hold onto the returned handle — keeping the original (now-invalidated) one
+                // makes the next OnDisconnect throw "Handle is no longer valid" at UnsubscribeAsync.
+                _serverDisconnectedSubscription = await _serverDisconnectedSubscription.ResumeAsync((serverId, _) => OnDisconnect("server-disconnected"));
+            }
+            else
+            {
+                _logger.LogWarning(
+                    "No subscription handle found for server '{ServerId}' on {HubName} for connection '{ConnectionId}' during activation; re-subscribing to the server-disconnect stream.",
+                    _serverId, _hubName, _connectionId);
+
+                var serverDisconnectedStream = _streamProvider.GetServerDisconnectionStream(_serverId);
+                _serverDisconnectedSubscription = await serverDisconnectedStream.SubscribeAsync(_ => OnDisconnect("server-disconnected"));
+            }
         }
     }
 
@@ -111,4 +125,11 @@ internal sealed class ClientGrain : IGrainBase, IClientGrain
     }
 
     public Task SendOneWay(InvocationMessage message) => Send(message);
+
+    private async Task<StreamSubscriptionHandle<Guid>?> GetSubscriptionHandleAsync(Guid serverId)
+    {
+        var stream = _streamProvider.GetServerDisconnectionStream(serverId);
+        var handles = await stream.GetAllSubscriptionHandles();
+        return handles.FirstOrDefault();
+    }
 }

--- a/src/SignalR.Orleans/ConnectionGroups/ConnectionGroupGrain.cs
+++ b/src/SignalR.Orleans/ConnectionGroups/ConnectionGroupGrain.cs
@@ -37,9 +37,20 @@ internal sealed class ConnectionGroupGrain : IConnectionGroupGrain, IGrainBase
 
         var resumeSubscriptionTasks = _state.State.ConnectionIds.Select(async connectionId =>
         {
-            var clientDisconnectStream = _streamProvider.GetClientDisconnectionStream(connectionId);
-            var subscriptionHandle = (await clientDisconnectStream.GetAllSubscriptionHandles())[0];
-            await subscriptionHandle.ResumeAsync((connectionId, _) => Remove(connectionId));
+            var subscriptionHandle = await GetSubscriptionHandleAsync(connectionId);
+            if (subscriptionHandle is not null)
+            {
+                await subscriptionHandle.ResumeAsync((connectionId, _) => Remove(connectionId));
+            }
+            else
+            {
+                _logger.LogWarning(
+                    "No subscription handle found for connection '{ConnectionId}' on {GroupType} group '{GroupId}' during activation; re-subscribing to the client-disconnect stream.",
+                    connectionId, _key.GroupType, _key.GroupId);
+
+                var clientDisconnectStream = _streamProvider.GetClientDisconnectionStream(connectionId);
+                await clientDisconnectStream.SubscribeAsync((connectionId, _) => Remove(connectionId));
+            }
         });
 
         return Task.WhenAll(resumeSubscriptionTasks);
@@ -59,9 +70,11 @@ internal sealed class ConnectionGroupGrain : IConnectionGroupGrain, IGrainBase
     {
         if (_state.State.ConnectionIds.Remove(connectionId))
         {
-            var stream = _streamProvider.GetClientDisconnectionStream(connectionId);
-            var handle = (await stream.GetAllSubscriptionHandles())[0];
-            await handle.UnsubscribeAsync();
+            var handle = await GetSubscriptionHandleAsync(connectionId);
+            if (handle is not null)
+            {
+                await handle.UnsubscribeAsync();
+            }
 
             if (_state.State.ConnectionIds.Count == 0)
             {
@@ -88,6 +101,15 @@ internal sealed class ConnectionGroupGrain : IConnectionGroupGrain, IGrainBase
         return SendAll(message, _state.State.ConnectionIds.Except(excludedConnectionIds));
     }
 
+    public Task SendOneWay(InvocationMessage message) => Send(message);
+
+    private async Task<StreamSubscriptionHandle<string>?> GetSubscriptionHandleAsync(string connectionId)
+    {
+        var stream = _streamProvider.GetClientDisconnectionStream(connectionId);
+        var handles = await stream.GetAllSubscriptionHandles();
+        return handles.FirstOrDefault();
+    }
+
     private Task SendAll([Immutable] InvocationMessage message, IEnumerable<string> connectionIds)
     {
         _logger.LogDebug("Sending message to {HubName}.{MethodName} on {GroupType} group '{GroupId}'.",
@@ -95,6 +117,4 @@ internal sealed class ConnectionGroupGrain : IConnectionGroupGrain, IGrainBase
 
         return Task.WhenAll(connectionIds.Select(connectionId => _grainFactory.GetClientGrain(_key.HubType, connectionId).Send(message)));
     }
-
-    public Task SendOneWay(InvocationMessage message) => Send(message);
 }

--- a/test/SignalR.Orleans.Tests/ConnectionGroupGrainTests.cs
+++ b/test/SignalR.Orleans.Tests/ConnectionGroupGrainTests.cs
@@ -1,0 +1,73 @@
+using System.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+using Orleans.Runtime;
+using Orleans.Storage;
+using SignalR.Orleans;
+using SignalR.Orleans.ConnectionGroups;
+using Xunit;
+
+namespace SignalR.Orleans.Tests;
+
+public class ConnectionGroupGrainTests : IClassFixture<OrleansFixture>
+{
+    private const string HubName = "MyHub";
+
+    private readonly OrleansFixture _fixture;
+
+    public ConnectionGroupGrainTests(OrleansFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    /// <summary>
+    /// Reproduces the scenario where a group grain's state contains a connection id, but the
+    /// client-disconnect stream has no persisted subscription handle (e.g. the handle was lost while
+    /// the connection id survived in state). On activation the grain must re-subscribe to the
+    /// disconnect stream, otherwise the stale connection id can never be cleaned up.
+    /// </summary>
+    [Fact]
+    public async Task OnActivate_WhenNoSubscriptionHandleExists_ReSubscribesSoDisconnectCleansUp()
+    {
+        var groupName = $"resub-{Guid.NewGuid():N}";
+        var connectionId = $"conn-{Guid.NewGuid():N}";
+
+        var grain = _fixture.Client.GetGroupGrain(HubName, groupName);
+
+        // Seed the grain's persisted state with a connection id WITHOUT ever subscribing to the
+        // client-disconnect stream. This mimics state that outlived its stream subscription handle.
+        var storage = _fixture.Silo.Services.GetRequiredKeyedService<IGrainStorage>(
+            SignalROrleansConstants.SIGNALR_ORLEANS_STORAGE_PROVIDER);
+
+        var seededState = new GrainState<ConnectionGroupGrainState>(
+            new ConnectionGroupGrainState { ConnectionIds = { connectionId } });
+
+        await storage.WriteStateAsync("ConnectionGroups", grain.GetGrainId(), seededState);
+
+        // Activating the grain (any call) loads the seeded state and runs OnActivateAsync.
+        Assert.Equal(1, await grain.Count());
+
+        // Simulate the client disconnecting by publishing to the client-disconnect stream, exactly
+        // as ClientGrain does on disconnect.
+        await _fixture.Client.GetOrleansSignalRStreamProvider()
+            .GetClientDisconnectionStream(connectionId)
+            .OnNextAsync(connectionId);
+
+        // If the grain re-subscribed on activation, the disconnect event removes the connection id.
+        await WaitForCountAsync(grain, expected: 0);
+    }
+
+    private static async Task WaitForCountAsync(IConnectionGroupGrain grain, int expected)
+    {
+        var sw = Stopwatch.StartNew();
+        while (await grain.Count() != expected)
+        {
+            if (sw.ElapsedMilliseconds > 5000)
+            {
+                throw new Exception(
+                    $"Group count did not reach {expected} within the timeout; the grain did not re-subscribe to the client-disconnect stream on activation.");
+            }
+
+            await Task.Delay(25);
+        }
+    }
+}


### PR DESCRIPTION
SignalR.Orleans grains stored stream subscription handles and, on reactivation, indexed the result of GetAllSubscriptionHandles() with [0]. When a silo restarts (or a subscription was never persisted), GetAllSubscriptionHandles() returns an empty collection, so [0] threw IndexOutOfRangeException and the grain failed to activate.

ClientGrain had the same issue as the connection groups grain; where reactivation would fail with an empty collection.

Changes:
- ConnectionGroupGrain `(await ...GetAllSubscriptionHandles())[0]` with a private GetSubscriptionHandleAsync(...) helper that returns handles.FirstOrDefault().
- ClientGrain: `(await ...GetAllSubscriptionHandles())[0]` with a private GetSubscriptionHandleAsync(...) helper that returns handles.FirstOrDefault().
- On activation, if no handle is found, log a warning and re-subscribe to the client/server disconnect stream instead of throwing.


Files:
- src/SignalR.Orleans/Clients/ClientGrain.cs
- src/SignalR.Orleans/ConnectionGroups/ConnectionGroupGrain.cs

refs: OrleansContrib/SignalR.Orleans#168